### PR TITLE
Update test workflow to generate versions.json

### DIFF
--- a/.github/tests/test_github_pages.yml
+++ b/.github/tests/test_github_pages.yml
@@ -53,6 +53,9 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           mkdocs build
 
+      - name: Generate versions.json
+        run: mike list --json > site/versions.json
+
       - name: Test Mike deployment (information only)
         run: |
           TEST_VERSION=${{ github.event.inputs.version }}
@@ -65,7 +68,7 @@ jobs:
       - name: Show versions that would be created
         run: |
           echo "Current version.json content:"
-          cat docs/versions.json || echo "versions.json does not exist or is empty"
+          cat site/versions.json || echo "versions.json does not exist or is empty"
           echo ""
           echo "This would generate a version in the documentation with:"
           TEST_VERSION=${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary
- add `mike list --json` step to the test workflow
- output the generated `site/versions.json` file instead of the one in `docs`

## Testing
- `act -j test_docs -W .github/tests/test_github_pages.yml -P version=0.0.2` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684109d8bb9c8333bdcca3d4e615fa7e