### PR TITLE
Fix deploy note in bump-version.rs

### DIFF
--- a/scripts/bump-version.rs
+++ b/scripts/bump-version.rs
@@ -62,7 +62,7 @@ impl VersionBumper {
         
         if deploy_choice == 3 {
             println!("{}Note:{} You can deploy this version later using:", YELLOW, NC);
-            println!("  {}./scripts/deploy-all-versions.sh{} (to deploy all versions)", BLUE, NC);
+            println!("  {}doc-cli deploy{} (to deploy all versions)", BLUE, NC);
             println!("  or");
             println!("  {}mike deploy v{} --branch gh-pages --push{} (to deploy just this version)", BLUE, new_version, NC);
         }


### PR DESCRIPTION
## Summary
- update bump-version script to reference `doc-cli deploy`
- rebuild the CLI tools and verify help output

## Testing
- `cargo build --release`
- `./target/release/doc-cli help | sed -n '20,36p'`

------
https://chatgpt.com/codex/tasks/task_e_684109d1b4108333ad3fb6b88e0deefe