### PR TITLE
Add CSS variables for three.js colors

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -3,6 +3,18 @@
  * Enhancing the particle background and overall aesthetics
  */
 
+/* Default warm colors for the THREE.js background */
+:root {
+  --three-particle-color: #ffa07a;
+  --three-line-color: #ff8a65;
+}
+
+/* Dark mode adjustments */
+[data-md-color-scheme="slate"] {
+  --three-particle-color: #ffcb8c;
+  --three-line-color: #ffb86b;
+}
+
 /* Ensure particle background container is properly positioned */
 #particles-background {
   position: fixed;

--- a/docs/assets/js/custom/threeBackground.js
+++ b/docs/assets/js/custom/threeBackground.js
@@ -16,8 +16,6 @@ class ThreeBackground {
       density: window.innerWidth > 768 ? 0.8 : 0.5, // Lower density on mobile
       scrollFactor: 0.05,
       particleSize: window.innerWidth > 768 ? 0.15 : 0.1,
-      particleColor: 0x0088ff,
-      lineColor: 0x0066cc,
       backgroundColor: 0x000000,
       particleCount: window.innerWidth > 768 ? 150 : 80, // Fewer particles on mobile
       maxConnections: window.innerWidth > 768 ? 5 : 3,  // Fewer connections on mobile
@@ -26,6 +24,19 @@ class ThreeBackground {
       updateFrequency: 1,                 // Update every frame by default
       ...options
     };
+
+    // Load colors from CSS variables
+    const styles = getComputedStyle(document.documentElement);
+    const particleColor = styles.getPropertyValue('--three-particle-color').trim();
+    const lineColor = styles.getPropertyValue('--three-line-color').trim();
+
+    if (particleColor) {
+      this.options.particleColor = new THREE.Color(particleColor);
+    }
+
+    if (lineColor) {
+      this.options.lineColor = new THREE.Color(lineColor);
+    }
 
     // Animation properties
     this.animationId = null;
@@ -181,6 +192,7 @@ class ThreeBackground {
     
     // Line material
     const lineMaterial = new THREE.LineBasicMaterial({
+      color: this.options.lineColor,
       vertexColors: true,
       blending: THREE.AdditiveBlending,
       transparent: true,


### PR DESCRIPTION
## Summary
- define `--three-particle-color` and `--three-line-color` in custom.css for light/dark themes
- load these variables in `threeBackground.js` and convert to `THREE.Color`
- apply the line color to the line material

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410d2d17ac83339f613eb0f9389709