### PR TITLE
Move index.css inline styles to separate file

### DIFF
--- a/docs/assets/css/landing-page-inline.css
+++ b/docs/assets/css/landing-page-inline.css
@@ -1,0 +1,27 @@
+/**
+ * CSS extracted from the inline <style> block in docs/index.md
+ * Provides layout tweaks specific to the landing page.
+ */
+
+/* Hide the first H1 in the content area */
+.md-typeset h1:first-of-type {
+  display: none;
+}
+
+.md-source-file {
+  display: none;
+}
+
+/* Reserve vertical space around the entire subtitle (typewriter + location) */
+.subtitle {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  /* Optionally force a minimum height so even an empty span still takes space */
+  /* min-height: 3em; */
+}
+
+/* Give the typewriter span its own inline-block box with vertical padding */
+.typewriter-text {
+  display: inline-block;
+  padding: 0.5rem 0;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,31 +3,6 @@ hide:
   - toc
 ---
 
-<style>  
-  /* Hide the first H1 in the content area */
-  .md-typeset h1:first-of-type {
-    display: none;
-  }
-
-  .md-source-file {
-    display: none;
-  }
-
-  /* Reserve vertical space around the entire subtitle (typewriter + location) */
-  .subtitle {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    /* Optionally force a minimum height so even an empty span still takes space */
-    /* min-height: 3em; */
-  }
-
-  /* Give the typewriter span its own inline‐block box with vertical padding */
-  .typewriter-text {
-    display: inline-block;
-    padding: 0.5rem 0;
-  }
-</style>
-
 <div markdown="1" class="home-page">
 
 <div class="scroll-progress"></div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ extra_css:
   - assets/css/landing-page-cta.css
   - assets/css/landing-page-interactive.css
   - assets/css/landing-page-typewriter-fix.css
+  - assets/css/landing-page-inline.css
   - assets/css/section-transitions.css
   - assets/css/scroll-indicator-fix.css
   - assets/css/components/test-scene-shared.css


### PR DESCRIPTION
## Summary
- create **landing-page-inline.css** for previously inline rules
- reference the new stylesheet in `extra_css`
- remove the original `<style>` block from `index.md`

## Testing
- `mkdocs build -q` *(fails: plugin missing)*
- `pip install -e .`
- `mkdocs build --strict` *(fails with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68410d31f570833385029193172b43d2