### PR TITLE
Improve hero layout and hide TOC

### DIFF
--- a/docs/assets/css/pages/home/extras.css
+++ b/docs/assets/css/pages/home/extras.css
@@ -9,6 +9,11 @@
   padding: 0 1rem;
 }
 
+/* Hide Table of Contents on the landing page */
+.landing-page .md-sidebar--secondary {
+  display: none;
+}
+
 /* Tagline styling */
 .tagline {
   font-size: 1.25rem;

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ hero:
 <section class="intro-section" id="intro">
 
   <div class="intro-section">
+  <img src="assets/images/me-today.png" alt="Brandon A. Calderon Morales" class="profile-image">
 
   <h2>Hi, I'm Brandon A. Calderon Morales 👋</h2>
 


### PR DESCRIPTION
## Summary
- add profile image to home page hero
- hide table of contents sidebar on landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68412321d42c83338c1cd33b2c44d26b