### PR TITLE
Fix home page title display

### DIFF
--- a/docs/assets/css/pages/home/extras.css
+++ b/docs/assets/css/pages/home/extras.css
@@ -15,7 +15,7 @@
 }
 
 /* Hide page title on the landing page */
-.landing-page .md-content__inner > h1:first-child {
+.landing-page .home-page-wrapper > h1:first-child {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- adjust CSS selector to hide the Home page title

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_68418a91347c8333af028eff328f54f8