### PR TITLE
Add landing page scroll snapping

### DIFF
--- a/docs/assets/css/pages/home/section-scroll.css
+++ b/docs/assets/css/pages/home/section-scroll.css
@@ -1,0 +1,32 @@
+/**
+ * Scroll snapping and accent colors for landing page
+ */
+.landing-page.scroll-container {
+  scroll-behavior: smooth;
+  scroll-snap-type: y mandatory;
+}
+
+.scroll-section {
+  scroll-snap-align: start;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  min-height: 100vh;
+}
+
+.landing-page {
+  --landing-accent: #2aa198;
+  --landing-accent-hover: #258b84;
+}
+
+.landing-page a.cta-button,
+.landing-page .social-button,
+.landing-page .secondary-link {
+  background-color: var(--landing-accent);
+  color: #ffffff !important;
+}
+
+.landing-page a.cta-button:hover,
+.landing-page .social-button:hover,
+.landing-page .secondary-link:hover {
+  background-color: var(--landing-accent-hover);
+}

--- a/docs/assets/js/custom/sectionScroller.js
+++ b/docs/assets/js/custom/sectionScroller.js
@@ -1,0 +1,49 @@
+"use strict";
+/**
+ * SectionScroller.js
+ * Implements scroll snapping for landing page sections
+ */
+import { defaultLogger } from './logger.js';
+
+const logger = defaultLogger.setModule('sectionScroller');
+
+class SectionScroller {
+  constructor() {
+    this.sections = [];
+    this.resizeHandler = this.applySectionHeights.bind(this);
+  }
+
+  init() {
+    if (!document.documentElement.classList.contains('landing-page')) {
+      logger.info('SectionScroller skipped: not on landing page');
+      return;
+    }
+
+    this.sections = Array.from(document.querySelectorAll('.scroll-section'));
+    if (this.sections.length === 0) {
+      logger.warn('No scroll sections found');
+      return;
+    }
+
+    this.applySectionHeights();
+    window.addEventListener('resize', this.resizeHandler);
+    document.documentElement.classList.add('scroll-container');
+    logger.info(`SectionScroller initialized with ${this.sections.length} sections`);
+  }
+
+  applySectionHeights() {
+    const vh = window.innerHeight;
+    this.sections.forEach(sec => {
+      sec.style.minHeight = `${vh}px`;
+    });
+    logger.debug(`Applied ${vh}px height to sections`, 'applySectionHeights');
+  }
+}
+
+export default SectionScroller;
+
+// Auto-init on DOM ready
+document.addEventListener('DOMContentLoaded', () => {
+  const scroller = new SectionScroller();
+  scroller.init();
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ hero:
 
 <div markdown="1" class="home-page">
 
-<section class="intro-section" id="intro">
+<section class="intro-section scroll-section" id="intro">
 
   <div class="intro-section">
   <img src="assets/images/me-today.png" alt="Brandon A. Calderon Morales" class="profile-image">
@@ -68,7 +68,7 @@ hero:
 
 <div class="section-divider"></div> <!-- cta section end -->
 
-<section class="tabbed-experience" id="tabs">
+<section class="tabbed-experience scroll-section" id="tabs">
 
 <h2 class="section-title">Discover More About Me</h2>
 
@@ -290,7 +290,7 @@ hero:
 
 <div class="section-divider"></div>
 
-<section class="final-cta" id="connect">
+<section class="final-cta scroll-section" id="connect">
   <h2>Let's Connect! 🤝</h2>
   <p>Thanks for visiting my profile! I'm always open to new connections, collaborations, and conversations.</p>
   

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ extra_css:
   - assets/css/pages/home/mobile.css
   - assets/css/pages/home/cards.css
   - assets/css/pages/home/scroll.css
+  - assets/css/pages/home/section-scroll.css
   - assets/css/pages/home/headings.css
   - assets/css/pages/home/tabs.css
   - assets/css/pages/home/cta.css
@@ -128,6 +129,7 @@ extra_javascript:
   - { "path": "assets/js/custom/threeBackground.js", "type": "module" }
   - { "path": "assets/js/custom/threeBackgroundFallback.js", "type": "module" }
   - { "path": "assets/js/custom/smoothScroll.js", "type": "module" }
+  - { "path": "assets/js/custom/sectionScroller.js", "type": "module" }
   - { "path": "assets/js/custom/performanceMonitor.js", "type": "module" }
   - { "path": "assets/js/custom/sectionTransitions.js", "type": "module" }
   - { "path": "assets/js/custom/initModernUI.js", "type": "module" }


### PR DESCRIPTION
## Summary
- enable scroll snapping for the landing page
- complement landing image with new accent color styles
- initialize new SectionScroller module
- include new module and styles in MkDocs config

## Testing
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d90b49e08333a645d32a6b3a31fa