### PR TITLE
Add repo nav links and restore dev_flow_mentor docs

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -35,4 +35,53 @@ nav:
     - repositories/index.md
     - Dev Flow Mentor: repositories/dev_flow_mentor/index.md
 
+    - my-life-as-a-dev: repositories/my_life_as_a_dev/index.md
+    - flowhive-creativity: repositories/flowhive_creativity/index.md
+    - family-fun-schedule: repositories/family_fun_schedule/index.md
+    - solid-infrastructure-architect: repositories/solid_infrastructure_architect/index.md
+    - dev-environment: repositories/dev_environment/index.md
+    - dev-environment-workflows: repositories/dev_environment_workflows/index.md
+    - Vimrc-No-Plugins: repositories/vimrc_no_plugins/index.md
+    - portfolio: repositories/portfolio/index.md
+    - golang-api: repositories/golang_api/index.md
+    - GoFundamentals: repositories/gofundamentals/index.md
+    - CSharpRefresher: repositories/csharprefresher/index.md
+    - ecommerce-template: repositories/ecommerce_template/index.md
+    - Construction-Ecommerce-Frontend: repositories/construction_ecommerce_frontend/index.md
+    - Construction-Ecommerce-Backend: repositories/construction_ecommerce_backend/index.md
+    - 3dTextThreeJss: repositories/3dtextthreejss/index.md
+    - ExperimentingWithThreeJs: repositories/experimentingwiththreejs/index.md
+    - Amazon-Clone: repositories/amazon_clone/index.md
+    - Angular-Typescript-Tutorial-Part-I: repositories/angular_typescript_tutorial_part_i/index.md
+    - Angular-Typescript-Tutorial-Part-II: repositories/angular_typescript_tutorial_part_ii/index.md
+    - FacebookMessenger-Clone: repositories/facebookmessenger_clone/index.md
+    - TravelAdvisor-Frontend: repositories/traveladvisor_frontend/index.md
+    - BookLibraryProject: repositories/booklibraryproject/index.md
+    - DayTripGenerator: repositories/daytripgenerator/index.md
+    - Chat-App-MicrosoftTeamsClone: repositories/chat_app_microsoftteamsclone/index.md
+    - FlashcardProject-Frontend: repositories/flashcardproject_frontend/index.md
+    - ReactWorkSheetExercises: repositories/reactworksheetexercises/index.md
+    - RockPaperScissorsLizardSpock_Python: repositories/rockpaperscissorslizardspock_python/index.md
+    - CreatingAMockCrypto: repositories/creatingamockcrypto/index.md
+    - SuperheroesCreatorProject: repositories/superheroescreatorproject/index.md
+    - TrashCollectorProject: repositories/trashcollectorproject/index.md
+    - SweepstakesGenerator: repositories/sweepstakesgenerator/index.md
+    - RobotsVsDinosaurs: repositories/robotsvsdinosaurs/index.md
+    - MusicLibraryProject-Backend: repositories/musiclibraryproject_backend/index.md
+    - FlashcardProject-Backend: repositories/flashcardproject_backend/index.md
+    - YouTubeCloneProject_Backend: repositories/youtubecloneproject_backend/index.md
+    - DebuggingProject: repositories/debuggingproject/index.md
+    - Portfolio-Site: repositories/portfolio_site/index.md
+    - Personal-Site-HTML5: repositories/personal_site_html5/index.md
+    - PortfolioWebsite: repositories/portfoliowebsite/index.md
+    - TinDogProject: repositories/tindogproject/index.md
+    - PersonalSite-NoBootsrap: repositories/personalsite_nobootsrap/index.md
+    - DOM-DocumentObjectModel: repositories/dom_documentobjectmodel/index.md
+    - JavaRefresh: repositories/javarefresh/index.md
+    - RockPaperScissorsLizardSpock_C-Sharp: repositories/rockpaperscissorslizardspock_c_sharp/index.md
+    - hw4: repositories/hw4/index.md
+    - hw5: repositories/hw5/index.md
+    - angular-example-code: repositories/angular_example_code/index.md
+    - Box_Physics: repositories/box_physics/index.md
+    - SQLZoo-Practice: repositories/sqlzoo_practice/index.md
   - Troubleshooting: troubleshooting

--- a/docs/repositories/dev_flow_mentor/index.md
+++ b/docs/repositories/dev_flow_mentor/index.md
@@ -1,4 +1,74 @@
-# dev-flow-mentor
-Documentation not available.
+# Welcome to your Lovable project
 
+## Project info
+
+**URL**: https://lovable.dev/projects/3d12c8fb-ad6a-4080-ba7d-f72ab72178d8
+
+## How can I edit this code?
+
+There are several ways of editing your application.
+
+**Use Lovable**
+
+Simply visit the [Lovable Project](https://lovable.dev/projects/3d12c8fb-ad6a-4080-ba7d-f72ab72178d8) and start prompting.
+
+Changes made via Lovable will be committed automatically to this repo.
+
+**Use your preferred IDE**
+
+If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
+
+The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+
+Follow these steps:
+
+```sh
+# Step 1: Clone the repository using the project's Git URL.
+git clone <YOUR_GIT_URL>
+
+# Step 2: Navigate to the project directory.
+cd <YOUR_PROJECT_NAME>
+
+# Step 3: Install the necessary dependencies.
+npm i
+
+# Step 4: Start the development server with auto-reloading and an instant preview.
+npm run dev
+```
+
+**Edit a file directly in GitHub**
+
+- Navigate to the desired file(s).
+- Click the "Edit" button (pencil icon) at the top right of the file view.
+- Make your changes and commit the changes.
+
+**Use GitHub Codespaces**
+
+- Navigate to the main page of your repository.
+- Click on the "Code" button (green button) near the top right.
+- Select the "Codespaces" tab.
+- Click on "New codespace" to launch a new Codespace environment.
+- Edit files directly within the Codespace and commit and push your changes once you're done.
+
+## What technologies are used for this project?
+
+This project is built with:
+
+- Vite
+- TypeScript
+- React
+- shadcn-ui
+- Tailwind CSS
+
+## How can I deploy this project?
+
+Simply open [Lovable](https://lovable.dev/projects/3d12c8fb-ad6a-4080-ba7d-f72ab72178d8) and click on Share -> Publish.
+
+## Can I connect a custom domain to my Lovable project?
+
+Yes, you can!
+
+To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
+
+Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 _It's been a while since this repo was updated._


### PR DESCRIPTION
## Summary
- link every repository page from `docs/.nav.yml`
- restore the missing documentation for Dev Flow Mentor

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6841dd53245c8333ac2e2e154ed865e6