### PR TITLE
Remove scroll snapping

### DIFF
--- a/docs/assets/css/pages/home/section-scroll.css
+++ b/docs/assets/css/pages/home/section-scroll.css
@@ -1,13 +1,11 @@
 /**
- * Scroll snapping and accent colors for landing page
+ * Layout and accent colors for landing page
  */
-.landing-page.scroll-container {
+.landing-page {
   scroll-behavior: smooth;
-  scroll-snap-type: y mandatory;
 }
 
 .scroll-section {
-  scroll-snap-align: start;
   padding-top: 2rem;
   padding-bottom: 2rem;
   min-height: 100vh;

--- a/docs/assets/js/custom/sectionScroller.js
+++ b/docs/assets/js/custom/sectionScroller.js
@@ -1,7 +1,7 @@
 "use strict";
 /**
  * SectionScroller.js
- * Implements scroll snapping for landing page sections
+ * Adjusts landing page sections to match viewport height
  */
 import { defaultLogger } from './logger.js';
 
@@ -27,7 +27,6 @@ class SectionScroller {
 
     this.applySectionHeights();
     window.addEventListener('resize', this.resizeHandler);
-    document.documentElement.classList.add('scroll-container');
     logger.info(`SectionScroller initialized with ${this.sections.length} sections`);
   }
 


### PR DESCRIPTION
## Summary
- remove scroll-snap CSS rules
- stop adding the scroll container class in section scroller
- keep sections sized to viewport

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68421419467083339848b11cd5171d4b