### PR TITLE
Add teal/tan palette and dynamic three.js theme update

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -5,19 +5,19 @@
 
 /* Theme colors for the THREE.js background */
 [data-md-color-scheme="default"] {
-  --three-particle-color: #708470;
-  --three-line-color: #556655;
-  --three-bg-start: #f0f4f0;
-  --three-bg-middle: #c2d0c2;
-  --three-bg-end: #708470;
+  --three-particle-color: #2b7d9d;
+  --three-line-color: #c5a067;
+  --three-bg-start: #f5f3ee;
+  --three-bg-middle: #e0dcd2;
+  --three-bg-end: #8ab3c2;
 }
 
 [data-md-color-scheme="slate"] {
-  --three-particle-color: #90a890;
-  --three-line-color: #708470;
-  --three-bg-start: #1e2420;
-  --three-bg-middle: #2c3a30;
-  --three-bg-end: #4d6050;
+  --three-particle-color: #61a7bd;
+  --three-line-color: #c5a067;
+  --three-bg-start: #0e1e23;
+  --three-bg-middle: #1e3037;
+  --three-bg-end: #274c55;
 }
 
 /* Ensure particle background container is properly positioned */

--- a/docs/assets/js/custom/threeBackground.js
+++ b/docs/assets/js/custom/threeBackground.js
@@ -5,6 +5,7 @@
  */
 import * as THREE from 'three';
 import { defaultLogger } from './logger.js';
+import ThemeDetector from './particleBackground/ThemeDetector.js';
 
 // Set up logger
 const logger = defaultLogger.setModule('threeBackground');
@@ -51,7 +52,11 @@ class ThreeBackground {
     
     // Set up event listeners
     this.setupEventListeners();
-    
+
+    // Set up theme detector to respond to palette changes
+    this.themeDetector = new ThemeDetector(() => this.updateTheme());
+    this.updateTheme();
+
     // Track scroll position for effects
     this.scrollY = 0;
     this.lastScrollY = 0;
@@ -517,6 +522,36 @@ class ThreeBackground {
       this.recreateParticles();
       
       logger.info('ThreeBackground restored to normal performance mode');
+    }
+  }
+
+  /**
+   * Update colors when theme changes
+   */
+  updateTheme() {
+    const styles = getComputedStyle(document.documentElement);
+    const planeColor = styles.getPropertyValue('--three-particle-color').trim();
+    const trailColor = styles.getPropertyValue('--three-line-color').trim();
+    const bgStart = styles.getPropertyValue('--three-bg-start').trim();
+    const bgMiddle = styles.getPropertyValue('--three-bg-middle').trim();
+    const bgEnd = styles.getPropertyValue('--three-bg-end').trim();
+
+    if (planeColor) {
+      this.options.planeColor = new THREE.Color(planeColor);
+      if (this.planes) {
+        this.planes.forEach(p => p.material.color.set(this.options.planeColor));
+      }
+    }
+
+    if (trailColor) {
+      this.options.trailColor = new THREE.Color(trailColor);
+      if (this.planes) {
+        this.planes.forEach(p => p.userData.trail.material.color.set(this.options.trailColor));
+      }
+    }
+
+    if (bgStart && bgMiddle && bgEnd) {
+      this.container.style.background = `linear-gradient(135deg, ${bgStart} 0%, ${bgMiddle} 70%, ${bgEnd} 100%)`;
     }
   }
   

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,16 +34,16 @@ theme:
   palette:
     # Dark mode (now listed first to make it default)
     - scheme: slate
-      primary: blue
-      accent: blue
+      primary: '#61a7bd'
+      accent: '#c5a067'
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
-    
+
     # Light mode
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: '#2b7d9d'
+      accent: '#c5a067'
       toggle:
         icon: material/weather-night
         name: Switch to dark mode


### PR DESCRIPTION
## Summary
- style: use teal and tan colors that match the profile photo
- chore: update Material palette colors for both light/dark
- feat: add theme detector to three.js background so plane and trail colors react to palette changes
- update gradient variables in custom CSS

## Testing
- `black --check . | tail -n 5`
- `isort --check . | tail -n 5`
- `pytest -q | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684234d5248c833398773c067dcd765d