### PR TITLE
Update theme to teal/tan and react to palette

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -5,19 +5,19 @@
 
 /* Theme colors for the THREE.js background */
 [data-md-color-scheme="default"] {
-  --three-particle-color: #708470;
-  --three-line-color: #556655;
-  --three-bg-start: #f0f4f0;
-  --three-bg-middle: #c2d0c2;
-  --three-bg-end: #708470;
+  --three-particle-color: #008080;
+  --three-line-color: #b38b6d;
+  --three-bg-start: #fdfaf6;
+  --three-bg-middle: #eaddc8;
+  --three-bg-end: #008080;
 }
 
 [data-md-color-scheme="slate"] {
-  --three-particle-color: #90a890;
-  --three-line-color: #708470;
-  --three-bg-start: #1e2420;
-  --three-bg-middle: #2c3a30;
-  --three-bg-end: #4d6050;
+  --three-particle-color: #64ffda;
+  --three-line-color: #d2b48c;
+  --three-bg-start: #00332f;
+  --three-bg-middle: #004c45;
+  --three-bg-end: #00695c;
 }
 
 /* Ensure particle background container is properly positioned */

--- a/docs/assets/js/custom/threeBackground.js
+++ b/docs/assets/js/custom/threeBackground.js
@@ -5,6 +5,7 @@
  */
 import * as THREE from 'three';
 import { defaultLogger } from './logger.js';
+import ThemeDetector from './particleBackground/ThemeDetector.js';
 
 // Set up logger
 const logger = defaultLogger.setModule('threeBackground');
@@ -48,6 +49,11 @@ class ThreeBackground {
     
     // Initialize THREE.js
     this.initializeScene();
+
+    // Set up theme detection to react to palette changes
+    this.themeDetector = new ThemeDetector(() => {
+      this.handleThemeChange();
+    });
     
     // Set up event listeners
     this.setupEventListeners();
@@ -446,6 +452,26 @@ class ThreeBackground {
 
   updateConnections() {
     // Trails are updated in updateParticles; nothing else to do here
+  }
+
+  handleThemeChange() {
+    const styles = getComputedStyle(document.documentElement);
+    const particleColor = styles.getPropertyValue('--three-particle-color').trim();
+    const lineColor = styles.getPropertyValue('--three-line-color').trim();
+
+    if (particleColor) {
+      this.options.planeColor = new THREE.Color(particleColor);
+      if (this.planes) {
+        this.planes.forEach(p => p.material.color.set(this.options.planeColor));
+      }
+    }
+
+    if (lineColor) {
+      this.options.trailColor = new THREE.Color(lineColor);
+      if (this.planes) {
+        this.planes.forEach(p => p.userData.trail.material.color.set(this.options.trailColor));
+      }
+    }
   }
 
   start() {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,16 +34,16 @@ theme:
   palette:
     # Dark mode (now listed first to make it default)
     - scheme: slate
-      primary: blue
-      accent: blue
+      primary: teal
+      accent: '#d2b48c'
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
     
     # Light mode
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: teal
+      accent: '#d2b48c'
       toggle:
         icon: material/weather-night
         name: Switch to dark mode


### PR DESCRIPTION
## Summary
- apply teal primary color and tan accent across dark and light palettes
- refresh gradient variables so the three.js background uses teal/tan
- make three.js background react when the theme changes

## Testing
- `pip install -r requirements.txt`
- `mkdocs build --strict -d /tmp/site` *(fails: "ai_plugin" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684236ff913c833387623125268f2f1e