### PR TITLE
Add teal/tan theme with dynamic colors

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -5,19 +5,19 @@
 
 /* Theme colors for the THREE.js background */
 [data-md-color-scheme="default"] {
-  --three-particle-color: #708470;
-  --three-line-color: #556655;
-  --three-bg-start: #f0f4f0;
-  --three-bg-middle: #c2d0c2;
-  --three-bg-end: #708470;
+  --three-plane-color: #008080;
+  --three-trail-color: #d2b48c;
+  --three-bg-start: #e0f2f1;
+  --three-bg-middle: #fff7e6;
+  --three-bg-end: #b2dfdb;
 }
 
 [data-md-color-scheme="slate"] {
-  --three-particle-color: #90a890;
-  --three-line-color: #708470;
-  --three-bg-start: #1e2420;
-  --three-bg-middle: #2c3a30;
-  --three-bg-end: #4d6050;
+  --three-plane-color: #80cbc4;
+  --three-trail-color: #bfa37c;
+  --three-bg-start: #1b2b28;
+  --three-bg-middle: #3b3223;
+  --three-bg-end: #294341;
 }
 
 /* Ensure particle background container is properly positioned */

--- a/docs/assets/js/custom/networkNodes.js
+++ b/docs/assets/js/custom/networkNodes.js
@@ -1,5 +1,8 @@
 "use strict";
 
+import ThemeDetector from './particleBackground/ThemeDetector.js';
+import { readPrimaryRGB } from './threeTheme.js';
+
 document.addEventListener('DOMContentLoaded', function() {
   // Only run on landing page
   if (!document.body.classList.contains('landing-page')) {
@@ -30,35 +33,20 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Colors based on theme
   function getThemeColors() {
-    const isDarkTheme = document.body.getAttribute('data-md-color-scheme') === 'slate';
-    
-    if (isDarkTheme) {
-      return {
-        nodeColor: 'rgba(100, 149, 237, 0.6)', // Cornflower blue for dark theme
-        lineColor: 'rgba(100, 149, 237, 0.2)',  // Lighter blue for connections
-        glowColor: 'rgba(100, 149, 237, 0.1)'   // Glow effect
-      };
-    } else {
-      return {
-        nodeColor: 'rgba(66, 133, 244, 0.6)',  // Google blue for light theme
-        lineColor: 'rgba(66, 133, 244, 0.15)', // Lighter blue for connections
-        glowColor: 'rgba(66, 133, 244, 0.05)'  // Glow effect
-      };
-    }
+    const rgb = readPrimaryRGB();
+    return {
+      nodeColor: `rgba(${rgb}, 0.6)`,
+      lineColor: `rgba(${rgb}, 0.15)`,
+      glowColor: `rgba(${rgb}, 0.05)`
+    };
   }
   
   let colors = getThemeColors();
-  
+
   // Watch for theme changes
-  const observer = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      if (mutation.attributeName === 'data-md-color-scheme') {
-        colors = getThemeColors();
-      }
-    });
+  const detector = new ThemeDetector(() => {
+    colors = getThemeColors();
   });
-  
-  observer.observe(document.body, { attributes: true });
   
   // Create nodes
   for (let i = 0; i < nodeCount; i++) {

--- a/docs/assets/js/custom/particleBackground/ParticleSystem.js
+++ b/docs/assets/js/custom/particleBackground/ParticleSystem.js
@@ -3,6 +3,7 @@
  * Manages the enhanced particle animation system
  */
 import * as THREE from 'three';
+import { readMaterialColors } from '../threeTheme.js';
 
 class ParticleSystem {
   /**
@@ -27,9 +28,9 @@ class ParticleSystem {
     this.maxConnections = isMobile ? 3 : 5;
     this.maxDistance = 8;
     this.lineOpacity = isDark ? 0.15 : 0.1;
-    
+
     // Color settings based on theme
-    this.setThemeColors(isDark);
+    this.setThemeColors();
     
     // Initialize the particle system
     this.init();
@@ -39,18 +40,11 @@ class ParticleSystem {
    * Set theme-based colors
    * @param {boolean} isDark - Whether dark mode is enabled
    */
-  setThemeColors(isDark) {
-    if (isDark) {
-      // Darker background - brighter particles
-      this.particleColor = 0x88aaff;
-      this.accentColor = 0x4488ff;
-      this.lineColor = 0x6677cc;
-    } else {
-      // Light background - subtler particles
-      this.particleColor = 0x225599;
-      this.accentColor = 0x3366bb;
-      this.lineColor = 0x334466;
-    }
+  setThemeColors() {
+    const { primaryColor, accentColor } = readMaterialColors(true);
+    this.particleColor = primaryColor.getHex();
+    this.accentColor = accentColor.getHex();
+    this.lineColor = primaryColor.getHex();
   }
   
   /**
@@ -236,7 +230,7 @@ class ParticleSystem {
    */
   updateTheme(isDark) {
     this.isDark = isDark;
-    this.setThemeColors(isDark);
+    this.setThemeColors();
     
     if (this.particleSystem) {
       this.particleSystem.material.color.set(this.particleColor);

--- a/docs/assets/js/custom/threeTheme.js
+++ b/docs/assets/js/custom/threeTheme.js
@@ -1,0 +1,47 @@
+"use strict";
+/**
+ * Utility functions for Three.js theme colors
+ */
+import * as THREE from 'three';
+
+export function readThreeColors() {
+  const styles = getComputedStyle(document.documentElement);
+  const plane = styles.getPropertyValue('--three-plane-color').trim();
+  const trail = styles.getPropertyValue('--three-trail-color').trim();
+
+  return {
+    planeColor: plane ? new THREE.Color(plane) : new THREE.Color(0xffffff),
+    trailColor: trail ? new THREE.Color(trail) : new THREE.Color(0xffffff)
+  };
+}
+
+/**
+ * Read primary and accent colors from the Material theme
+ * @param {boolean} asThree Return THREE.Color objects when true
+ */
+export function readMaterialColors(asThree = false) {
+  const styles = getComputedStyle(document.documentElement);
+  const primary = styles.getPropertyValue('--md-primary-fg-color').trim();
+  const accent = styles.getPropertyValue('--md-accent-fg-color').trim();
+
+  if (asThree) {
+    return {
+      primaryColor: primary ? new THREE.Color(primary) : new THREE.Color(0xffffff),
+      accentColor: accent ? new THREE.Color(accent) : new THREE.Color(0xffffff)
+    };
+  }
+
+  return {
+    primaryColor: primary || '#ffffff',
+    accentColor: accent || '#ffffff'
+  };
+}
+
+/**
+ * Read the primary color in RGB format for rgba() usage
+ */
+export function readPrimaryRGB() {
+  const styles = getComputedStyle(document.documentElement);
+  const rgb = styles.getPropertyValue('--md-primary-fg-color--rgb').trim();
+  return rgb || '255,255,255';
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,16 +34,16 @@ theme:
   palette:
     # Dark mode (now listed first to make it default)
     - scheme: slate
-      primary: blue
-      accent: blue
+      primary: '#008080'
+      accent: '#d2b48c'
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
-    
+
     # Light mode
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: '#008080'
+      accent: '#d2b48c'
       toggle:
         icon: material/weather-night
         name: Switch to dark mode


### PR DESCRIPTION
## Summary
- switch Material theme palette to teal and tan
- centralize theme color utilities
- make network nodes and particle system react to palette changes

## Testing
- `node -v`
- `mkdocs build -f mkdocs.yml -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423eae4338833393ab3d295ab757d5