### PR TITLE
Add simple makefile for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help setup serve build cli
+
+help:
+	@echo "Common commands:"
+	@echo "  make setup   - Install Python dependencies and setup project"
+	@echo "  make serve   - Run MkDocs development server"
+	@echo "  make build   - Build MkDocs documentation"
+	@echo "  make cli     - Build and run documentation CLI tools"
+
+setup:
+	pip install --upgrade pip
+	pip install -r requirements.txt
+	pip install -e .
+
+serve:
+	PYTHONPATH=$(PWD) mkdocs serve
+
+build:
+	PYTHONPATH=$(PWD) mkdocs build
+
+cli:
+	./doc-cli.sh


### PR DESCRIPTION
## Summary
- add a `Makefile` with helper commands to install requirements, run the mkdocs server, build the docs, and run the doc-cli

## Testing
- `pytest -q`
- `make help`


------
https://chatgpt.com/codex/tasks/task_e_684259a62bb88333b7b667036a660fea