### PR TITLE
Improve script reusability

### DIFF
--- a/scripts/generate_repo_pages.py
+++ b/scripts/generate_repo_pages.py
@@ -1,37 +1,29 @@
+import json
 import re
-import requests
 from pathlib import Path
 from datetime import datetime, timedelta
+
+from utils import slug, cached_get
 
 OWNER = "BA-CalderonMorales"
 BASE_DIR = Path(__file__).resolve().parent.parent / "docs" / "repositories"
 INDEX_FILE = Path(__file__).resolve().parent.parent / "docs" / "repositories" / "index.md"
 
 
-def slug(name: str) -> str:
-    return name.lower().replace('-', '_')
-
-
 def fetch_repo_info(repo: str):
     url = f"https://api.github.com/repos/{OWNER}/{repo}"
-    try:
-        resp = requests.get(url, timeout=10)
-        if resp.status_code == 200:
-            return resp.json()
-    except requests.RequestException:
-        pass
+    text = cached_get(url)
+    if text:
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
     return None
 
 
 def fetch_readme(repo: str, branch: str) -> str | None:
     url = f"https://raw.githubusercontent.com/{OWNER}/{repo}/{branch}/README.md"
-    try:
-        resp = requests.get(url, timeout=10)
-        if resp.status_code == 200:
-            return resp.text
-    except requests.RequestException:
-        pass
-    return None
+    return cached_get(url)
 
 
 def get_repo_names() -> list[str]:

--- a/scripts/sync_repo_docs.py
+++ b/scripts/sync_repo_docs.py
@@ -1,6 +1,6 @@
-import os
-import requests
 from pathlib import Path
+
+from utils import slug, cached_get
 
 REPOS = {
     "Vimrc-No-Plugins": "develop",
@@ -12,17 +12,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent / "docs" / "repositories"
 RAW_URL_TEMPLATE = "https://raw.githubusercontent.com/{repo}/{branch}/README.md"
 
 
-def slug(name: str) -> str:
-    return name.lower().replace('-', '_')
-
-
 def fetch_readme(repo: str, branch: str) -> str:
     url = RAW_URL_TEMPLATE.format(repo=f"BA-CalderonMorales/{repo}", branch=branch)
-    resp = requests.get(url, timeout=10)
-    if resp.status_code == 200:
-        return resp.text
-    else:
-        return f"# {repo}\nREADME not available."
+    text = cached_get(url)
+    if text:
+        return text
+    return f"# {repo}\nREADME not available."
 
 
 def write_doc(repo: str, content: str):

--- a/scripts/update_index_links.py
+++ b/scripts/update_index_links.py
@@ -1,11 +1,11 @@
 import re
 from pathlib import Path
 
+from utils import slug
+
 INDEX_FILE = Path(__file__).resolve().parent.parent / "docs" / "repositories" / "index.md"
 
 
-def slug(name: str) -> str:
-    return name.lower().replace('-', '_')
 
 
 def main():

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import requests
+
+# Shared session for all network calls
+_session = requests.Session()
+
+# Cache directory to store fetched resources
+CACHE_DIR = Path(__file__).resolve().parent / ".cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def slug(name: str) -> str:
+    """Convert a repository name to a filesystem-friendly slug."""
+    return name.lower().replace("-", "_")
+
+
+def cached_get(url: str, *, timeout: int = 10) -> str | None:
+    """Fetch a URL and cache the result on disk."""
+    cache_key = hashlib.sha256(url.encode()).hexdigest()
+    cache_file = CACHE_DIR / cache_key
+
+    if cache_file.exists():
+        return cache_file.read_text(encoding="utf-8")
+
+    try:
+        resp = _session.get(url, timeout=timeout)
+        if resp.status_code == 200:
+            cache_file.write_text(resp.text, encoding="utf-8")
+            return resp.text
+    except requests.RequestException:
+        pass
+    return None


### PR DESCRIPTION
## Summary
- add `utils.py` with shared slug/cached_get helpers
- refactor repo scripts to use shared utilities and local caching

## Testing
- `python -m py_compile scripts/*.py`
- `python -m py_compile mkdocs_plugins/*.py`
- `python scripts/generate_repo_pages.py`
- `python scripts/sync_repo_docs.py`
- `python scripts/update_index_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68425c5019a883339e809d40dde6c31d