### PR TITLE
Create super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on: # yamllint disable-line rule:truthy
+  push: null
+  pull_request: null
+
+permissions: {}
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v7.4.0 # x-release-please-version
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,8 +1,11 @@
 name: Lint
 
 on: # yamllint disable-line rule:truthy
-  push: null
-  pull_request: null
+  push:
+    branches: main 
+
+  pull_request:
+    branches: main 
 
 permissions: {}
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -2,10 +2,10 @@ name: Lint
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: main 
+    branches: [main] 
 
   pull_request:
-    branches: main 
+    branches: [main] 
 
 permissions: {}
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate code linting using Super-Linter. The workflow is configured to run on pushes and pull requests targeting the `main` branch.

### New GitHub Actions workflow:

* [`.github/workflows/super-linter.yml`](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33R1-R35): Added a workflow named "Lint" that uses Super-Linter to check code quality. The workflow runs on `ubuntu-latest`, checks out the code with full git history, and uses the `super-linter/super-linter@v7.4.0` action. It is triggered on `push` and `pull_request` events for the `main` branch.