### PR TITLE
Fix spacing in three.js vendor file

### DIFF
--- a/docs/assets/js/vendor/three.module.js
+++ b/docs/assets/js/vendor/three.module.js
@@ -15207,7 +15207,7 @@ class WebGLRenderer {
 
 			_pixelRatio = value;
 
-			this.setSize( _width, _height, false );
+                        this.setSize(_width, _height, false);
 
 		};
 


### PR DESCRIPTION
## Summary
- fix spacing in docs/assets/js/vendor/three.module.js

## Testing
- `make setup`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6843f282f1d083338ae4800474da5dab