### PR TITLE
Fix shared css path and test scene containers

### DIFF
--- a/docs/assets/css/components/cellular-prism/styles.css
+++ b/docs/assets/css/components/cellular-prism/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Cellular Prism Component */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 cellular-prism {
   display: block;

--- a/docs/assets/css/components/color-particle-artifact/styles.css
+++ b/docs/assets/css/components/color-particle-artifact/styles.css
@@ -4,7 +4,7 @@
  */
 
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Base component container */
 color-particle-artifact {

--- a/docs/assets/css/components/dreamscape-proto4/styles.css
+++ b/docs/assets/css/components/dreamscape-proto4/styles.css
@@ -4,7 +4,7 @@
  */
 
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Canvas element styling */
 .dreamscape-canvas {

--- a/docs/assets/css/components/dreamscape-proto6/styles.css
+++ b/docs/assets/css/components/dreamscape-proto6/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Interactive Canvas Dreamscape */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 dreamscape-proto6 {
   display: block;

--- a/docs/assets/css/components/ghibli-masterpiece/styles.css
+++ b/docs/assets/css/components/ghibli-masterpiece/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Ghibli Forest Spirits Component */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Component-specific styling */
 ghibli-masterpiece {

--- a/docs/assets/css/components/intergalactic-scene/styles.css
+++ b/docs/assets/css/components/intergalactic-scene/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Intergalactic Scene Component */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Component-specific styling */
 intergalactic-scene {

--- a/docs/assets/css/components/kaleidoscopic-scene/styles.css
+++ b/docs/assets/css/components/kaleidoscopic-scene/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Kaleidoscopic Scene Component */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Component-specific styling */
 kaleidoscopic-scene {

--- a/docs/assets/css/components/physics-playground/styles.css
+++ b/docs/assets/css/components/physics-playground/styles.css
@@ -1,6 +1,6 @@
 /* Styles for the Physics Playground Component */
 /* Import shared test scene styles */
-@import url('./test-scene-shared.css');
+@import url('../test-scene-shared.css');
 
 /* Component-specific styling */
 physics-playground {

--- a/docs/assets/js/components/dreamscape-proto4/dreamscape-proto4.js
+++ b/docs/assets/js/components/dreamscape-proto4/dreamscape-proto4.js
@@ -427,7 +427,8 @@ if (!customElements.get('dreamscape-proto4')) {
   customElements.define('dreamscape-proto4', class extends HTMLElement {
     connectedCallback() {
       // Create a new scene when the element is added to the DOM
-      this.classList.add('dreamscape-container');
+      // Use the shared test scene container styling
+      this.classList.add('test-scene-container');
       this.scene = new DreamscapeProto4(this, {
         debug: window.location.hostname === 'localhost' || 
                window.location.hostname === '127.0.0.1' ||

--- a/docs/assets/js/components/dreamscape/dreamscape.js
+++ b/docs/assets/js/components/dreamscape/dreamscape.js
@@ -496,7 +496,8 @@ if (!customElements.get('stars-motion-scene')) {
   customElements.define('stars-motion-scene', class extends HTMLElement {
     connectedCallback() {
       // Create a new scene when the element is added to the DOM
-      this.classList.add('dreamscape-container');
+      // Use the shared test scene container styling
+      this.classList.add('test-scene-container');
       this.scene = new StarsMotionScene(this, {
         debug: window.location.hostname === 'localhost' || 
                window.location.hostname === '127.0.0.1' ||


### PR DESCRIPTION
## Summary
- fix broken `@import` paths for test scene CSS
- use the shared `test-scene-container` class for `stars-motion-scene` and `dreamscape-proto4`

## Testing
- `make setup`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_684402755e2c833385842995c9b8eb6c