### PR TITLE
Add black hole effects and adjust theme colors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ theme:
   palette:
     # Dark mode (now listed first to make it default)
     - scheme: slate
-      primary: blue grey
+      primary: blue
       accent: light blue
       toggle:
         icon: material/weather-sunny
@@ -44,8 +44,8 @@ theme:
     
     # Light mode
     - scheme: default
-      primary: blue grey
-      accent: blue
+      primary: blue
+      accent: light blue
       toggle:
         icon: material/weather-night
         name: Switch to dark mode


### PR DESCRIPTION
## Summary
- slow down cloud motion and vary altitude
- create black hole renderings at poles with simple gravitational pull
- move camera closer for dramatic perspective
- update site palette to a blue color scheme

## Testing
- `make build` *(fails: mkdocs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a5cd41bc8333adc2012a8d6c8da2