### PR TITLE
Refine modal styling and simplify theme

### DIFF
--- a/docs/assets/css/common/modal.css
+++ b/docs/assets/css/common/modal.css
@@ -1,0 +1,20 @@
+/* Minimal dialog and modal styles */
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.3);
+}
+
+dialog,
+.modal {
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  border: none;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 1.5rem;
+  width: 90%;
+  max-width: 420px;
+}
+
+.modal.is-hidden {
+  display: none;
+}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -4,18 +4,17 @@
  */
 
 :root {
-  --three-particle-color: #1976d2; /* Default light theme color */
-  /* Custom Ghibli-inspired background colors */
-  --md-default-bg-color: #f1f8e9; /* Soft light green for light theme */
-  --md-primary-fg-color: #2e7d32; /* Forest green accent */
+  --three-particle-color: #0067b3;
+  --md-default-bg-color: #ffffff;
+  --md-default-fg-color: #000000;
+  --md-primary-fg-color: #005a9c;
 }
 
 [data-theme="slate"] {
-  --three-particle-color: #4fc3f7; /* Brighter cyan for better visibility */
-  --three-line-color: #4fc3f7;
-  /* Custom warm brown for dark theme */
-  --md-default-bg-color: #3e2723; /* Rich warm brown */
-  --md-default-fg-color--light: #8d6e63; /* Lighter brown accent */
+  --three-particle-color: #7aa6ff;
+  --three-line-color: #7aa6ff;
+  --md-default-bg-color: #121212;
+  --md-default-fg-color--light: #e0e0e0;
 }
 
 /* Ensure particle background container is properly positioned */
@@ -44,35 +43,22 @@
   bottom: 0;
   z-index: -1;
   pointer-events: none;
-  transition: background 0.3s ease-in-out;
-}
-
-/* Overlay gradients based on theme - Updated for Ghibli colors */
-[data-theme="default"] .md-main::before {
-  background: radial-gradient(circle at 70% 20%, rgba(76, 175, 80, 0.1), rgba(241, 248, 233, 0.4));
-}
-
-[data-theme="slate"] .md-main::before {
-  background: radial-gradient(circle at 30% 80%, rgba(141, 110, 99, 0.1), rgba(62, 39, 35, 0.5));
+  background: none;
 }
 
 /* Enhance header on transparent background */
 .md-header {
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  transition: all 0.3s ease;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  transition: none;
   position: relative;
-  z-index: 1000; /* Higher z-index to ensure header is above all content */
+  z-index: 1000;
 }
 
 /* Header in light mode - Ensure proper contrast */
-[data-theme="default"] .md-header {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-/* Header in dark mode - Fix colors */
+[data-theme="default"] .md-header,
 [data-theme="slate"] .md-header {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border: none;
 }
 
 /* Fix ALL navigation text visibility in light mode */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ plugins:
 extra_css:
   - assets/css/custom.css
   - assets/css/common/animations.css
+  - assets/css/common/modal.css
   - assets/css/pages/home/base.css
   - assets/css/pages/home/extras.css
   - assets/css/pages/home/mobile.css


### PR DESCRIPTION
## Summary
- add minimal CSS for modal and dialog elements
- simplify color scheme in `custom.css`
- remove gradients and blur effects for a cleaner look
- include the new CSS in `mkdocs.yml`

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcb6d56c08333a348f167df99c1f3