### PR TITLE
Add Pickaxe RAG integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,3 +398,8 @@ For the most accurate and up-to-date project structure, please refer to the [Git
    <p>This project is licensed under the Apache License 2.0 - see the <a href="LICENSE">LICENSE</a> file for details.</p>
 </div>
 </details>
+
+## AI Features
+
+- **OpenAI Integration** via `ai_plugin` for content generation.
+- **Pickaxe RAG** via `pickaxe_rag_plugin` to embed answers directly in docs. This uses the [Pickaxe](https://github.com/hatchet-dev/pickaxe) open-source project. See [Pickaxe RAG Integration](docs/pickaxe_rag.md).

--- a/docs/docs-as-code/index.md
+++ b/docs/docs-as-code/index.md
@@ -41,6 +41,7 @@ Our AI integration plugin provides:
 3. **Documentation Enhancement**: Improve existing content with AI suggestions
 
 See the [AI Demo](./ai-demo/index.md) for a live demonstration.
+Additional support for [Pickaxe RAG](../pickaxe_rag.md) allows you to embed answers directly in docs.
 
 ## Implementation Architecture
 

--- a/docs/pickaxe_rag.md
+++ b/docs/pickaxe_rag.md
@@ -1,0 +1,33 @@
+# Pickaxe RAG Integration
+
+This project can run Retrieval Augmented Generation (RAG) using [Pickaxe](https://github.com/hatchet-dev/pickaxe) during the MkDocs build process.
+
+## Placeholders
+
+Add a placeholder to any Markdown page:
+
+```html
+<div class="pickaxe-rag" data-query="What does this project do?">
+  Loading answer...
+</div>
+```
+
+When `PICKAXE_API_KEY` is set, the `pickaxe_rag_plugin` will query your Pickaxe deployment and replace the placeholder with the returned answer.
+
+## Environment Variables
+
+- `PICKAXE_API_KEY` – API token for Pickaxe
+- `PICKAXE_HOST` – Optional base URL (default: `https://api.pickaxe.ai`)
+
+## Usage
+
+Set the environment variables and build the site:
+
+```bash
+export PICKAXE_API_KEY=your-key
+make build
+```
+
+The generated site will include Pickaxe-powered answers wherever placeholders are used.
+
+You can explore Pickaxe's source code and CLI at [github.com/hatchet-dev/pickaxe](https://github.com/hatchet-dev/pickaxe).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ plugins:
   - search
   - tags
   - ai_plugin
+  - pickaxe_rag_plugin
   - minify:
       minify_html: true
       minify_js: true

--- a/mkdocs_plugins/__init__.py
+++ b/mkdocs_plugins/__init__.py
@@ -4,6 +4,7 @@ MkDocs plugins package
 This package contains custom plugins for MkDocs.
 Currently includes:
 - AI Plugin: For AI-assisted content generation
+- PickaxeRAGPlugin: Integrates Pickaxe for Retrieval Augmented Generation
 """
 
 # Version of the plugins package
@@ -12,8 +13,9 @@ __version__ = "0.1.0"
 # Expose the AIPlugin class at the package level for easier imports
 try:
     from mkdocs_plugins.ai_plugin import AIPlugin
+    from mkdocs_plugins.pickaxe_rag_plugin import PickaxeRAGPlugin
 
-    __all__ = ["AIPlugin"]
+    __all__ = ["AIPlugin", "PickaxeRAGPlugin"]
 except ImportError:
     # This allows the package to be imported even if submodules are missing
     # (helps with module discovery)

--- a/mkdocs_plugins/pickaxe_rag_plugin.py
+++ b/mkdocs_plugins/pickaxe_rag_plugin.py
@@ -1,0 +1,48 @@
+import logging
+import os
+import re
+
+from dotenv import load_dotenv
+from mkdocs.plugins import BasePlugin
+import requests
+
+log = logging.getLogger("mkdocs.plugins.pickaxe_rag")
+
+class PickaxeRAGPlugin(BasePlugin):
+    """Plugin that replaces placeholders with Pickaxe RAG answers."""
+
+    def on_config(self, config):
+        load_dotenv()
+        self.api_key = os.environ.get("PICKAXE_API_KEY")
+        self.host = os.environ.get("PICKAXE_HOST", "https://api.pickaxe.ai")
+        if not self.api_key:
+            log.warning("Pickaxe RAG: No API key set. Placeholders will remain unchanged.")
+        return config
+
+    def on_page_markdown(self, markdown, page, config, files):
+        pattern = re.compile(r'<div class="pickaxe-rag" data-query="(.*?)">.*?</div>', re.DOTALL)
+
+        def repl(match):
+            query = match.group(1)
+            if not self.api_key:
+                return match.group(0)
+            try:
+                resp = requests.post(
+                    f"{self.host}/rag",
+                    json={"query": query, "doc": page.file.src_path},
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                    timeout=30,
+                )
+                if resp.ok:
+                    data = resp.json()
+                    return data.get("answer", match.group(0))
+                log.error("Pickaxe RAG: API error %s", resp.status_code)
+            except Exception as exc:
+                log.error("Pickaxe RAG: request failed: %s", exc)
+            return match.group(0)
+
+        return pattern.sub(repl, markdown)
+
+
+def get_plugin():
+    return PickaxeRAGPlugin()

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     entry_points={
         "mkdocs.plugins": [
             "ai_plugin = mkdocs_plugins.ai_plugin:AIPlugin",
+            "pickaxe_rag_plugin = mkdocs_plugins.pickaxe_rag_plugin:PickaxeRAGPlugin",
         ],
     },
     # External dependencies required by this plugin
@@ -26,6 +27,7 @@ setup(
         "mkdocs>=1.6.1",  # MkDocs base package
         "openai>=1.3.0",  # OpenAI API client for AI content generation
         "python-dotenv>=1.0.0",  # For loading API keys from .env files
+        "requests>=2.31.0",  # HTTP client used by Pickaxe RAG integration
     ],
     # Uncomment and fill these in if you want to publish the plugin to PyPI
     # url="https://github.com/BA-CalderonMorales/my-life-as-a-dev",


### PR DESCRIPTION
## Summary
- implement `pickaxe_rag_plugin` for Retrieval Augmented Generation
- expose plugin via package and mkdocs config
- document Pickaxe usage
- mention AI features in README
- add requests dependency for the plugin

## Testing
- `python -m py_compile mkdocs_plugins/pickaxe_rag_plugin.py`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6859f5cca47883339b5e1f651e567c7f