### PR TITLE
Update docs and workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -72,6 +72,9 @@ jobs:
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
           echo "Latest tag: $LATEST_TAG"
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build and deploy with Mike
         if: github.event_name != 'pull_request'
         run: |

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1342,5 +1342,15 @@ The key is to write clean, testable, functional code that evolves through small,
 
 ## Project Standards
 
-This repository uses MkDocs with the Material theme for documentation and includes Rust-based tooling. Adhere to the official best practices and conventions for MkDocs, MkDocs Material, and Rust throughout the project.
+This repository uses MkDocs with the Material theme and a custom AI plugin. All documentation tooling is Python based and the helper CLI is written in Rust.
+
+### Working with the Docs
+
+- Use **Python 3.10+**.
+- Run `make setup` to install dependencies and register the local plugin.
+- Run `make serve` while editing to start the MkDocs development server.
+- Run `make build` to generate the static site.
+- Documentation versions are managed with `mike`; use `./scripts/bump-version.sh` to create new versions when needed.
+
+Follow official best practices for MkDocs, MkDocs Material, and Rust across the project.
 

--- a/RULES.md
+++ b/RULES.md
@@ -5,22 +5,19 @@ These rules keep development consistent across the project. The document is inte
 ## General Principles
 
 - Follow Test-Driven Development. Write tests before production code and keep changes small.
-- Use strict TypeScript and prefer immutable patterns.
+- Use Python 3.10 or higher and prefer immutable patterns and small pure functions.
 - When looking for solutions, consult **context7** and the guidance in **MEMORY.md**. Do not copy text from MEMORY.md into this file.
 
 ## Local Workflow
 
-Use these npm scripts during feature work:
+Use these Makefile targets during feature work:
 
-- `npm ci` – install dependencies
-- `npm start` – run the Metro bundler
-- `npm run ios` – run the iOS app
-- `npm run android` – run the Android app
-- `npm test` – run the full test suite
-- `npm run typecheck` – run TypeScript checks
-- `npm run build` – build release artifacts with Fastlane
+- `make setup` – install Python dependencies and the local MkDocs plugin
+- `make serve` – start the MkDocs development server
+- `make build` – build the static site
+- `make cli` – run the Rust-based documentation CLI
 
-Run `npm ci`, `npm test`, `npm run typecheck`, and `npm run build` before pushing changes. CI uses the same commands.
+Run `make setup` and `make build` before pushing changes. CI uses the same commands.
 
 ## Commit Standards
 
@@ -48,7 +45,7 @@ After merging into `develop`, automatically open a PR that merges `develop` into
 
 ## Continuous Integration
 
-All dependencies must be installed with `npm ci` in CI jobs. The Super-Linter runs on every pull request via `.github/workflows/super-linter.yml`.
+All dependencies must be installed using `make setup` in CI jobs. The Super-Linter runs on every pull request via `.github/workflows/super-linter.yml`.
 
-Ensure we find ways to mitigate any current Super-Linter failures as we continue to make incremental changes. Failures should not cause us to break existing functionality or alter the current UI appearance. Take a balanced approach when addressing linter issues.
+Ensure we find ways to mitigate any current Super-Linter failures as we continue to make incremental changes. Failures should not cause us to break existing functionality or alter the current documentation appearance. Take a balanced approach when addressing linter issues.
 


### PR DESCRIPTION
## Summary
- clarify TDD rules and update workflow commands for MkDocs
- document how to build the docs in MEMORY
- fix deployment preview by configuring GitHub Pages

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_68600f17faf8833393d70f25e390a768