### PR TITLE
Feature: add GH_TOKEN support for repo scripts

### DIFF
--- a/docs/docs-as-code/index.md
+++ b/docs/docs-as-code/index.md
@@ -56,6 +56,12 @@ graph TD
     I -->|Requests| G
 ```
 
+## Automation Scripts
+
+Helper scripts in `scripts/python` keep repository pages up to date. These utilities
+fetch README files using `utils.cached_get`. Set the environment variable `GH_TOKEN`
+(or `GITHUB_TOKEN`) to authenticate GitHub requests and avoid rate limits.
+
 ## Best Practices
 
 When working with this docs-as-code platform:

--- a/scripts/python/utils.py
+++ b/scripts/python/utils.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 
 import requests
 
 # Shared session for all network calls
 _session = requests.Session()
+
+GITHUB_TOKEN = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
 
 # Cache directory to store fetched resources
 CACHE_DIR = Path(__file__).resolve().parent / ".cache"
@@ -18,16 +21,27 @@ def slug(name: str) -> str:
     return name.lower().replace("-", "_")
 
 
-def cached_get(url: str, *, timeout: int = 10) -> str | None:
-    """Fetch a URL and cache the result on disk."""
+def cached_get(
+    url: str, *, timeout: int = 10, headers: dict[str, str] | None = None
+) -> str | None:
+    """Fetch a URL and cache the result on disk.
+
+    If ``GH_TOKEN`` or ``GITHUB_TOKEN`` is set in the environment, it is used
+    for GitHub requests unless an ``Authorization`` header is already provided.
+    """
     cache_key = hashlib.sha256(url.encode()).hexdigest()
     cache_file = CACHE_DIR / cache_key
 
     if cache_file.exists():
         return cache_file.read_text(encoding="utf-8")
 
+    if headers is None:
+        headers = {}
+    if GITHUB_TOKEN and "github.com" in url and "Authorization" not in headers:
+        headers["Authorization"] = f"token {GITHUB_TOKEN}"
+
     try:
-        resp = _session.get(url, timeout=timeout)
+        resp = _session.get(url, timeout=timeout, headers=headers)
         if resp.status_code == 200:
             cache_file.write_text(resp.text, encoding="utf-8")
             return resp.text


### PR DESCRIPTION
## Summary
- allow repo automation scripts to use `GH_TOKEN`/`GITHUB_TOKEN`
- mention automation scripts and new env variable in docs

## Codex CI
- `make setup`
- `make build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6860183c0eb083338cae29b353e53f94