### PR TITLE
Feature: update repo page generator

### DIFF
--- a/docs/docs-as-code/index.md
+++ b/docs/docs-as-code/index.md
@@ -61,6 +61,8 @@ graph TD
 Helper scripts in `scripts/python` keep repository pages up to date. These utilities
 fetch README files using `utils.cached_get`. Set the environment variable `GH_TOKEN`
 (or `GITHUB_TOKEN`) to authenticate GitHub requests and avoid rate limits.
+`generate_repo_pages.py` supports `--base-dir` to control where pages are written
+and `--force-refresh` to bypass the cache when fetching files.
 
 ## Best Practices
 

--- a/scripts/python/generate_repo_pages.py
+++ b/scripts/python/generate_repo_pages.py
@@ -2,19 +2,20 @@ import json
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
+import argparse
 
 from utils import cached_get, slug
 
 OWNER = "BA-CalderonMorales"
-BASE_DIR = Path(__file__).resolve().parent.parent / "docs" / "repositories"
+DEFAULT_BASE_DIR = Path(__file__).resolve().parent.parent / "docs" / "repositories"
 INDEX_FILE = (
     Path(__file__).resolve().parent.parent / "docs" / "repositories" / "index.md"
 )
 
 
-def fetch_repo_info(repo: str):
+def fetch_repo_info(repo: str, *, force: bool = False):
     url = f"https://api.github.com/repos/{OWNER}/{repo}"
-    text = cached_get(url)
+    text = cached_get(url, force=force)
     if text:
         try:
             return json.loads(text)
@@ -23,9 +24,9 @@ def fetch_repo_info(repo: str):
     return None
 
 
-def fetch_readme(repo: str, branch: str) -> str | None:
+def fetch_readme(repo: str, branch: str, *, force: bool = False) -> str | None:
     url = f"https://raw.githubusercontent.com/{OWNER}/{repo}/{branch}/README.md"
-    return cached_get(url)
+    return cached_get(url, force=force)
 
 
 def get_repo_names() -> list[str]:
@@ -34,12 +35,12 @@ def get_repo_names() -> list[str]:
     return pattern.findall(text)
 
 
-def create_page(repo: str):
-    info = fetch_repo_info(repo)
+def create_page(repo: str, *, base_dir: Path, force: bool = False):
+    info = fetch_repo_info(repo, force=force)
     content = ""
     if info and not info.get("private", False):
         branch = info.get("default_branch", "main")
-        readme = fetch_readme(repo, branch)
+        readme = fetch_readme(repo, branch, force=force)
         if readme:
             content = readme
         else:
@@ -58,14 +59,31 @@ def create_page(repo: str):
     else:
         content += "\n\n_It's been a while since this repo was updated._"
 
-    target_dir = BASE_DIR / slug(repo)
+    target_dir = base_dir / slug(repo)
     target_dir.mkdir(parents=True, exist_ok=True)
     (target_dir / "index.md").write_text(content.rstrip() + "\n", encoding="utf-8")
 
 
-def main():
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate repository pages")
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=DEFAULT_BASE_DIR,
+        help="Directory where pages will be created",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Ignore cached responses and fetch fresh data",
+    )
+    args = parser.parse_args()
+
+    base_dir = args.base_dir
+    base_dir.mkdir(parents=True, exist_ok=True)
+
     for repo in get_repo_names():
-        create_page(repo)
+        create_page(repo, base_dir=base_dir, force=args.force_refresh)
 
 
 if __name__ == "__main__":

--- a/scripts/python/utils.py
+++ b/scripts/python/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 from pathlib import Path
 
 import requests
@@ -18,11 +19,17 @@ CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 def slug(name: str) -> str:
     """Convert a repository name to a filesystem-friendly slug."""
-    return name.lower().replace("-", "_")
+    slugified = name.lower()
+    slugified = re.sub(r"[^a-z0-9]+", "_", slugified)
+    return slugified.strip("_")
 
 
 def cached_get(
-    url: str, *, timeout: int = 10, headers: dict[str, str] | None = None
+    url: str,
+    *,
+    timeout: int = 10,
+    headers: dict[str, str] | None = None,
+    force: bool = False,
 ) -> str | None:
     """Fetch a URL and cache the result on disk.
 
@@ -32,7 +39,7 @@ def cached_get(
     cache_key = hashlib.sha256(url.encode()).hexdigest()
     cache_file = CACHE_DIR / cache_key
 
-    if cache_file.exists():
+    if cache_file.exists() and not force:
         return cache_file.read_text(encoding="utf-8")
 
     if headers is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest import mock
+from pathlib import Path
+import tempfile
+
+import scripts.python.utils as utils
+
+class TestSlug(unittest.TestCase):
+    def test_slug_sanitizes(self):
+        self.assertEqual(utils.slug("My Repo"), "my_repo")
+        self.assertEqual(utils.slug("Already_Slug"), "already_slug")
+        self.assertEqual(utils.slug("Something--Weird!!!"), "something_weird")
+
+class TestCachedGet(unittest.TestCase):
+    def test_force_refresh_bypasses_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # patch cache dir and session
+            url = "https://example.com/data"
+            cache_key = utils.hashlib.sha256(url.encode()).hexdigest()
+            cache_file = Path(tmpdir) / cache_key
+            cache_file.write_text("cached")
+            with mock.patch.object(utils, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(utils, "_session") as session:
+                    session.get.return_value.status_code = 200
+                    session.get.return_value.text = "fresh"
+                    result = utils.cached_get(url, force=True)
+                    self.assertEqual(result, "fresh")
+                    session.get.assert_called_once()
+    def test_uses_cache_when_available(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = "https://example.com/data"
+            cache_key = utils.hashlib.sha256(url.encode()).hexdigest()
+            cache_file = Path(tmpdir) / cache_key
+            cache_file.write_text("cached")
+            with mock.patch.object(utils, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(utils, "_session") as session:
+                    result = utils.cached_get(url)
+                    self.assertEqual(result, "cached")
+                    session.get.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new CLI arguments to `generate_repo_pages.py`
- improve `slug` and `cached_get` helper functions
- document new options in docs-as-code guide
- add unit tests for new utilities

## Codex CI
- `make setup` ran successfully
- `make build` built the documentation
- `python -m unittest discover -s tests` passed


------
https://chatgpt.com/codex/tasks/task_e_686030eb16648333880d42e8cb19212f