### PR TITLE
Feature: add JSON helper for repo scripts

### DIFF
--- a/docs/docs-as-code/index.md
+++ b/docs/docs-as-code/index.md
@@ -59,8 +59,9 @@ graph TD
 ## Automation Scripts
 
 Helper scripts in `scripts/python` keep repository pages up to date. These utilities
-fetch README files using `utils.cached_get`. Set the environment variable `GH_TOKEN`
-(or `GITHUB_TOKEN`) to authenticate GitHub requests and avoid rate limits.
+fetch README files using `utils.cached_get` and query the GitHub API with
+`utils.cached_get_json`. Set the environment variable `GH_TOKEN` (or
+`GITHUB_TOKEN`) to authenticate GitHub requests and avoid rate limits.
 `generate_repo_pages.py` supports `--base-dir` to control where pages are written
 and `--force-refresh` to bypass the cache when fetching files.
 

--- a/scripts/python/generate_repo_pages.py
+++ b/scripts/python/generate_repo_pages.py
@@ -1,10 +1,9 @@
-import json
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
 import argparse
 
-from utils import cached_get, slug
+from utils import cached_get_json, cached_get, slug
 
 OWNER = "BA-CalderonMorales"
 DEFAULT_BASE_DIR = Path(__file__).resolve().parent.parent / "docs" / "repositories"
@@ -15,13 +14,7 @@ INDEX_FILE = (
 
 def fetch_repo_info(repo: str, *, force: bool = False):
     url = f"https://api.github.com/repos/{OWNER}/{repo}"
-    text = cached_get(url, force=force)
-    if text:
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            return None
-    return None
+    return cached_get_json(url, force=force)
 
 
 def fetch_readme(repo: str, branch: str, *, force: bool = False) -> str | None:

--- a/scripts/python/utils.py
+++ b/scripts/python/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import json
 from pathlib import Path
 
 import requests
@@ -54,4 +55,15 @@ def cached_get(
             return resp.text
     except requests.RequestException:
         pass
+    return None
+
+
+def cached_get_json(url: str, *, force: bool = False, timeout: int = 10, headers: dict[str, str] | None = None):
+    """Fetch a URL expecting a JSON response and return the parsed data."""
+    text = cached_get(url, force=force, timeout=timeout, headers=headers)
+    if text:
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
     return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,5 +38,44 @@ class TestCachedGet(unittest.TestCase):
                     self.assertEqual(result, "cached")
                     session.get.assert_not_called()
 
+class TestCachedGetJson(unittest.TestCase):
+    def test_returns_json_from_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = "https://example.com/data.json"
+            cache_key = utils.hashlib.sha256(url.encode()).hexdigest()
+            cache_file = Path(tmpdir) / cache_key
+            cache_file.write_text('{"foo": 1}')
+            with mock.patch.object(utils, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(utils, "_session") as session:
+                    result = utils.cached_get_json(url)
+                    self.assertEqual(result, {"foo": 1})
+                    session.get.assert_not_called()
+
+    def test_force_refresh_fetches_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = "https://example.com/data.json"
+            cache_key = utils.hashlib.sha256(url.encode()).hexdigest()
+            cache_file = Path(tmpdir) / cache_key
+            cache_file.write_text("{\"foo\": 1}")
+            with mock.patch.object(utils, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(utils, "_session") as session:
+                    session.get.return_value.status_code = 200
+                    session.get.return_value.text = '{"bar": 2}'
+                    result = utils.cached_get_json(url, force=True)
+                    self.assertEqual(result, {"bar": 2})
+                    session.get.assert_called_once()
+
+    def test_invalid_json_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url = "https://example.com/bad.json"
+            cache_key = utils.hashlib.sha256(url.encode()).hexdigest()
+            cache_file = Path(tmpdir) / cache_key
+            cache_file.write_text("not json")
+            with mock.patch.object(utils, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(utils, "_session") as session:
+                    result = utils.cached_get_json(url)
+                    self.assertIsNone(result)
+                    session.get.assert_not_called()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support JSON API requests with `cached_get_json`
- use the new helper in `generate_repo_pages.py`
- document the new utility in docs-as-code guide
- add comprehensive tests for `cached_get_json`

## Codex CI
- `make setup` ran successfully
- `make build` ran successfully
- `python -m unittest discover -s tests -v` passed

------
https://chatgpt.com/codex/tasks/task_e_68605025ade08333826d08686f099f21