### PR TITLE
Cleanup: fix docs links and 404

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,5 @@
+# Page Not Found
+
+Oops! The page you were looking for doesn't exist.
+
+[Return Home](index.md)

--- a/docs/docs-as-code/index.md
+++ b/docs/docs-as-code/index.md
@@ -28,7 +28,7 @@ This site leverages several powerful technologies:
 
 We've extended the standard MkDocs capabilities with:
 
-- **[OpenAI Integration](./ai-demo/index.md)**: AI-assisted content generation
+- **OpenAI Integration**: AI-assisted content generation *(demo coming soon)*
 - **Version Management**: Multiple documentation versions via mike
 - **Custom CLI Tools**: Rust-based utilities for documentation management
 
@@ -40,7 +40,7 @@ Our AI integration plugin provides:
 2. **Code Samples**: Generate relevant code snippets based on natural language descriptions
 3. **Documentation Enhancement**: Improve existing content with AI suggestions
 
-See the [AI Demo](./ai-demo/index.md) for a live demonstration.
+An interactive AI demo is planned for a future release.
 
 ## Implementation Architecture
 

--- a/docs/repositories/immersive-awe-canvas/index.md
+++ b/docs/repositories/immersive-awe-canvas/index.md
@@ -27,8 +27,8 @@ Immersive Awe Canvas is a web-based application that allows users to explore and
 
 ## Getting Started
 
-Visit the [Quick Start](/repositories/immersive-awe-canvas/quick_start/) guide for setup instructions and development workflows.
+Visit the [Quick Start](quick_start/index.md) guide for setup instructions and development workflows.
 
 ## Documentation
 
-Explore the [Details](/repositories/immersive-awe-canvas/details/) section for in-depth information about the project's architecture, features, and contribution guidelines.
+Explore the [Details](details/index.md) section for in-depth information about the project's architecture, features, and contribution guidelines.

--- a/docs/repositories/immersive-awe-canvas/quick_start/index.md
+++ b/docs/repositories/immersive-awe-canvas/quick_start/index.md
@@ -91,6 +91,6 @@ The project is automatically deployed to GitHub Pages on every push to the `main
 
 ## Next Steps
 
-- Explore the [Details](/repositories/immersive-awe-canvas/details/) for advanced configuration
-- Check out the [keyboard shortcuts](#keyboard-shortcuts) for navigation
-- Learn how to [create custom worlds](/repositories/immersive-awe-canvas/details/#creating-custom-worlds)
+- Explore the [Details](../details/index.md) for advanced configuration
+- Check out the [keyboard shortcuts](../details/index.md#keyboard-shortcuts) for navigation
+- Learn how to [create custom worlds](../details/index.md#creating-custom-worlds)

--- a/docs/repositories/index.md
+++ b/docs/repositories/index.md
@@ -20,9 +20,9 @@ A comprehensive documentation portfolio built with MkDocs Material, featuring AI
 
 - :material-github: [Repository](https://github.com/BA-CalderonMorales/my-life-as-a-dev)
 - :material-web: [Live Demo](https://ba-calderonmorales.github.io/my-life-as-a-dev/)
-- :material-book-open-variant: [Documentation](/repositories/my-life-as-a-dev/)
-  - [Quick Start](/repositories/my-life-as-a-dev/quick_start/)
-  - [Project Details](/repositories/my-life-as-a-dev/details/)
+- :material-book-open-variant: [Documentation](my-life-as-a-dev/index.md)
+  - [Quick Start](my-life-as-a-dev/quick_start/index.md)
+  - [Project Details](my-life-as-a-dev/details/index.md)
 
 ### 2. Immersive Awe Canvas
 
@@ -30,9 +30,9 @@ A creative coding environment for building and exploring interactive 3D scenes i
 
 - :material-github: [Repository](https://github.com/BA-CalderonMorales/immersive-awe-canvas)
 - :material-web: [Live Demo](https://immersive-awe-canvas.lovable.app)
-- :material-book-open-variant: [Documentation](/repositories/immersive-awe-canvas/)
-  - [Quick Start](/repositories/immersive-awe-canvas/quick_start/)
-  - [Project Details](/repositories/immersive-awe-canvas/details/)
+- :material-book-open-variant: [Documentation](immersive-awe-canvas/index.md)
+  - [Quick Start](immersive-awe-canvas/quick_start/index.md)
+  - [Project Details](immersive-awe-canvas/details/index.md)
 
 ### 3. Shadow Scroll Blossom
 
@@ -40,9 +40,9 @@ An interactive canvas that creates beautiful particle effects and visualizations
 
 - :material-github: [Repository](https://github.com/BA-CalderonMorales/shadow-scroll-blossom)
 - :material-web: [Live Demo](https://ba-calderonmorales.github.io/shadow-scroll-blossom/)
-- :material-book-open-variant: [Documentation](/repositories/shadow-scroll-blossom/)
-  - [Quick Start](/repositories/shadow-scroll-blossom/quick_start/)
-  - [Project Details](/repositories/shadow-scroll-blossom/details/)
+- :material-book-open-variant: [Documentation](shadow-scroll-blossom/index.md)
+  - [Quick Start](shadow-scroll-blossom/quick_start/index.md)
+  - [Project Details](shadow-scroll-blossom/details/index.md)
 
 ### 4. Rust Terminal Forge
 
@@ -50,9 +50,9 @@ A secure, browser-based terminal emulator built with React, TypeScript, and Rust
 
 - :material-github: [Repository](https://github.com/BA-CalderonMorales/rust-terminal-forge)
 - :material-web: [Live Demo](https://ba-calderonmorales.github.io/rust-terminal-forge/)
-- :material-book-open-variant: [Documentation](/repositories/rust-terminal-forge/)
-  - [Quick Start](/repositories/rust-terminal-forge/quick_start/)
-  - [Project Details](/repositories/rust-terminal-forge/details/)
+- :material-book-open-variant: [Documentation](rust-terminal-forge/index.md)
+  - [Quick Start](rust-terminal-forge/quick_start/index.md)
+  - [Project Details](rust-terminal-forge/details/index.md)
 
 ## Documentation Structure
 

--- a/docs/repositories/my-life-as-a-dev/index.md
+++ b/docs/repositories/my-life-as-a-dev/index.md
@@ -18,7 +18,7 @@ This project serves as my personal documentation hub, showcasing my work, though
 
 - :material-github: [GitHub Repository](https://github.com/BA-CalderonMorales/my-life-as-a-dev)
 - :material-web: [Live Demo](https://ba-calderonmorales.github.io/my-life-as-a-dev/)
-- :material-api: [AI Demo](/ai-demo/)
+- :material-api: AI Demo *(coming soon)*
 
 ## Project Status
 
@@ -29,8 +29,8 @@ This project serves as my personal documentation hub, showcasing my work, though
 
 ## Getting Started
 
-Visit the [Quick Start](/repositories/my-life-as-a-dev/quick_start/) guide for setup instructions and development workflows.
+Visit the [Quick Start](quick_start/index.md) guide for setup instructions and development workflows.
 
 ## Documentation
 
-Explore the [Details](/repositories/my-life-as-a-dev/details/) section for in-depth information about the project's architecture, features, and contribution guidelines.
+Explore the [Details](details/index.md) section for in-depth information about the project's architecture, features, and contribution guidelines.

--- a/docs/repositories/my-life-as-a-dev/quick_start/index.md
+++ b/docs/repositories/my-life-as-a-dev/quick_start/index.md
@@ -84,4 +84,4 @@ cargo build --release
 
 ## Next Steps
 
-- Explore the [Details](/repositories/my-life-as-a-dev/details/) section for advanced configuration
+- Explore the [Details](../details/index.md) section for advanced configuration

--- a/docs/repositories/rust-terminal-forge/index.md
+++ b/docs/repositories/rust-terminal-forge/index.md
@@ -27,8 +27,8 @@ Rust Terminal Forge is a web-based terminal emulator built with React, TypeScrip
 
 ## Getting Started
 
-Visit the [Quick Start](/repositories/rust-terminal-forge/quick_start/) guide for setup instructions and development workflows.
+Visit the [Quick Start](quick_start/index.md) guide for setup instructions and development workflows.
 
 ## Documentation
 
-Explore the [Details](/repositories/rust-terminal-forge/details/) section for in-depth information about the project's architecture, features, and contribution guidelines.
+Explore the [Details](details/index.md) section for in-depth information about the project's architecture, features, and contribution guidelines.

--- a/docs/repositories/rust-terminal-forge/quick_start/index.md
+++ b/docs/repositories/rust-terminal-forge/quick_start/index.md
@@ -91,6 +91,6 @@ The project is automatically deployed to GitHub Pages on every push to the `main
 
 ## Next Steps
 
-- Explore the [Details](/repositories/rust-terminal-forge/details/) for advanced configuration
-- Learn about the [terminal features](/repositories/rust-terminal-forge/details/#terminal-features)
-- Check out the [keyboard shortcuts](/repositories/rust-terminal-forge/details/#keyboard-shortcuts)
+- Explore the [Details](../details/index.md) for advanced configuration
+- Learn about the [terminal features](../details/index.md#terminal-features)
+- Check out the [keyboard shortcuts](../details/index.md#keyboard-shortcuts)

--- a/docs/repositories/shadow-scroll-blossom/index.md
+++ b/docs/repositories/shadow-scroll-blossom/index.md
@@ -27,8 +27,8 @@ Shadow Scroll Blossom is an interactive canvas that creates colorful particle tr
 
 ## Getting Started
 
-Visit the [Quick Start](/repositories/shadow-scroll-blossom/quick_start/) guide for setup instructions and development workflows.
+Visit the [Quick Start](quick_start/index.md) guide for setup instructions and development workflows.
 
 ## Documentation
 
-Explore the [Details](/repositories/shadow-scroll-blossom/details/) section for in-depth information about the project's architecture, features, and contribution guidelines.
+Explore the [Details](details/index.md) section for in-depth information about the project's architecture, features, and contribution guidelines.

--- a/docs/repositories/shadow-scroll-blossom/quick_start/index.md
+++ b/docs/repositories/shadow-scroll-blossom/quick_start/index.md
@@ -81,6 +81,6 @@ The project is automatically deployed to GitHub Pages on every push to the `main
 
 ## Next Steps
 
-- Explore the [Details](/repositories/shadow-scroll-blossom/details/) for advanced configuration
-- Learn how to [create custom themes](/repositories/shadow-scroll-blossom/details/#custom-themes)
-- Check out the [keyboard shortcuts](/repositories/shadow-scroll-blossom/details/#keyboard-shortcuts)
+- Explore the [Details](../details/index.md) for advanced configuration
+- Learn how to [create custom themes](../details/index.md#custom-themes)
+- Check out the [keyboard shortcuts](../details/index.md#keyboard-shortcuts)


### PR DESCRIPTION
## Summary
- clean up broken links across the docs module
- add a simple `404.md` page

## Codex CI
- `make setup` *(warning about dependency resolution but succeeded)*
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68605d82c7a883339a3e1a7acbe3fe09