### PR TITLE
chore(deps): batch resolve all open Dependabot alerts and bump zensical

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ tomli-w>=1.0.0
 
 # Image Optimization Plugin
 # Required for build-time image optimization (WebP conversion, responsive sizes)
-Pillow>=10.0.0
+Pillow>=12.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ mkdocs-panzoom-plugin>=0.1.9
 mkdocs-minify-plugin>=0.7.1
 mkdocs-print-site-plugin>=2.7.3
 
-mike>=2.1.3
+mike>=2.2.0
 
 # Zensical - Modern static site generator from Material for MkDocs team
 zensical>=0.0.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ openai>=1.3.0
 python-dotenv>=1.0.0
 requests>=2.31.0
 markdown>=3.5.1
-jinja2>=3.1.2
+jinja2>=3.1.6
 mkdocs-glightbox>=0.3.0
 
 # AI Proxy (GitHub Models via Azure AI Inference) for per-page chat

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mkdocs-material>=9.5.24
 pymdown-extensions>=10.14.3
 
 mkdocs-awesome-nav>=3.1.1
-mkdocs-git-revision-date-localized-plugin>=1.4.5
+mkdocs-git-revision-date-localized-plugin>=1.5.1
 mkdocs-git-authors-plugin>=0.9.5
 mkdocs-panzoom-plugin>=0.1.9
 mkdocs-minify-plugin>=0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ python-dotenv>=1.0.0
 requests>=2.31.0
 markdown>=3.5.1
 jinja2>=3.1.6
-mkdocs-glightbox>=0.3.0
+mkdocs-glightbox>=0.5.2
 
 # AI Proxy (GitHub Models via Azure AI Inference) for per-page chat
 azure-ai-inference

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ mkdocs-print-site-plugin>=2.7.3
 mike>=2.2.0
 
 # Zensical - Modern static site generator from Material for MkDocs team
-zensical>=0.0.30
+zensical>=0.0.37
 
 # AI Plugin Dependencies
 openai>=1.3.0


### PR DESCRIPTION
This PR supersedes and resolves all currently open Dependabot dependency updates that were conflicting with each other, plus bumps zensical to latest.

**Supersedes:**
- #127 — mkdocs-git-revision-date-localized-plugin >=1.5.1
- #128 — Pillow >=12.2.0
- #129 — mkdocs-glightbox >=0.5.2
- #130 — jinja2 >=3.1.6
- #131 — mike >=2.2.0

**Additional bumps:**
- zensical >=0.0.30 → >=0.0.37
- setuptools >=61.0 → >=82.0.1 (resurrects closed #125)

All changes cherry-picked from Dependabot branches with conflict resolution applied.