### PR TITLE
feat(ui): elemental ink minimalism redesign

### DIFF
--- a/docs/assets/css/background.css
+++ b/docs/assets/css/background.css
@@ -1,54 +1,11 @@
 /* ============================================
-   Background - Scene Integration
-   Content floats over the world, not boxed inside it
+   Background — Solid Surfaces
+   No blur, no glass, no scene.
+   Content sits directly on the page.
    ============================================ */
 
 .threejs-bg-container {
-    position: fixed;
-    inset: 0;
-    z-index: 0;
-    pointer-events: none;
-    overflow: hidden;
-    opacity: 0;
-    transition: opacity 800ms var(--mlad-ease-standard);
-}
-
-.threejs-bg-container canvas {
-    display: block;
-    width: 100%;
-    height: 100%;
-    filter: saturate(1.02) contrast(1.04);
-}
-
-.threejs-bg-container.is-ready {
-    opacity: var(--mlad-scene-opacity-page);
-}
-
-body[data-mlad-scene="home"] .threejs-bg-container.is-ready,
-.landing-page .threejs-bg-container.is-ready {
-    opacity: var(--mlad-scene-opacity-home);
-}
-
-body[data-mlad-scene="none"] .threejs-bg-container,
-.canvas-page .threejs-bg-container {
-    opacity: 0 !important;
-}
-
-@media screen and (max-width: 48rem) {
-    .threejs-bg-container.is-ready {
-        opacity: var(--mlad-scene-opacity-mobile);
-    }
-
-    body[data-mlad-scene="home"] .threejs-bg-container.is-ready,
-    .landing-page .threejs-bg-container.is-ready {
-        opacity: var(--mlad-scene-opacity-home-mobile);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .threejs-bg-container {
-        display: none;
-    }
+    display: none !important;
 }
 
 .md-main,
@@ -74,23 +31,23 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     z-index: 1;
 }
 
-/* Content inner - frosted glass over the scene */
+/* Content inner — flat, no glass */
 .md-content__inner {
-    background: var(--mlad-surface-overlay);
-    -webkit-backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
-    backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
+    background: transparent;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     border: none;
-    border-radius: var(--mlad-radius-lg);
+    border-radius: 0;
     box-shadow: none;
-    padding: clamp(1.5rem, 2.5vw, 2rem);
-    margin: var(--mlad-space-sm) var(--mlad-space-xs) var(--mlad-space-md);
+    padding: var(--mlad-space-md) var(--mlad-space-sm) var(--mlad-space-lg);
+    margin: 0;
 }
 
-/* Sidebars - frosted glass */
+/* Sidebars — flat */
 .md-sidebar--primary,
 .md-sidebar--secondary {
     padding: 0;
-    margin: var(--mlad-space-sm) 0;
+    margin: 0;
     border: none;
 }
 
@@ -105,11 +62,11 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 .md-sidebar--secondary .md-sidebar__inner {
     position: relative;
     z-index: 1;
-    background: var(--mlad-surface-overlay);
-    -webkit-backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
-    backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
+    background: transparent;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     border: none;
-    border-radius: var(--mlad-radius-md);
+    border-radius: 0;
     box-shadow: none;
     padding: var(--mlad-space-sm) var(--mlad-space-md) var(--mlad-space-md);
 }
@@ -134,8 +91,8 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 
 .md-sidebar--primary .md-nav__link,
 .md-sidebar--secondary .md-nav__link {
-    border-radius: var(--mlad-radius-sm);
-    padding: 0.35rem 0.5rem;
+    border-radius: 0;
+    padding: 0.3rem 0.4rem;
     transition: color var(--mlad-duration-fast) var(--mlad-ease-standard);
 }
 
@@ -158,14 +115,14 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     font-weight: 500;
 }
 
-/* Header - translucent, floating */
+/* Header — solid, no blur */
 .md-header,
 .md-tabs {
     background: var(--mlad-header-bg);
-    -webkit-backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
-    backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     color: var(--mlad-header-fg);
-    border-bottom: none;
+    border-bottom: 1px solid var(--mlad-border-soft);
 }
 
 .md-header {
@@ -180,7 +137,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 
 .md-header .md-header__button.md-icon:hover,
 .md-header .md-header__button.md-icon:focus-visible {
-    background: var(--mlad-menu-btn-bg-hover);
+    background: var(--mlad-surface-muted);
     border-radius: 0;
 }
 
@@ -189,20 +146,20 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     color: var(--md-accent-fg-color);
 }
 
-/* Footer - tonal separation, no border */
+/* Footer — solid surface */
 .md-footer {
     background: var(--mlad-surface-solid);
-    border-top: none;
+    border-top: 1px solid var(--mlad-border-soft);
 }
 
-/* Mobile overrides - solid surfaces, no blur for performance */
+/* Mobile overrides — solid surfaces */
 @media screen and (max-width: 76.25rem) {
     .md-sidebar--primary {
         top: 0 !important;
         height: 100% !important;
         margin: 0 !important;
         background: var(--mlad-surface-solid) !important;
-        border-right: none !important;
+        border-right: 1px solid var(--mlad-border-soft) !important;
         border-radius: 0 !important;
         box-shadow: none !important;
         -webkit-backdrop-filter: none !important;
@@ -210,7 +167,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     }
 
     .md-content__inner {
-        background: var(--mlad-surface-solid) !important;
+        background: transparent !important;
         -webkit-backdrop-filter: none !important;
         backdrop-filter: none !important;
         border-radius: 0;
@@ -236,7 +193,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 
     .md-drawer {
         background: var(--mlad-surface-solid) !important;
-        border-right: none !important;
+        border-right: 1px solid var(--mlad-border-soft) !important;
         opacity: 1 !important;
     }
 
@@ -247,7 +204,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     }
 
     [data-md-toggle="drawer"]:checked ~ .md-overlay {
-        background-color: rgba(0, 0, 0, 0.45) !important;
+        background-color: rgba(0, 0, 0, 0.35) !important;
     }
 }
 
@@ -259,7 +216,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 [data-md-toggle="drawer"]:checked ~ .md-overlay {
     pointer-events: auto !important;
     filter: none !important;
-    background-color: rgba(0, 0, 0, 0.45) !important;
+    background-color: rgba(0, 0, 0, 0.35) !important;
 }
 
 .md-drawer {
@@ -286,8 +243,8 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     display: flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.4rem 0.6rem;
-    background: var(--mlad-surface-elevated);
+    padding: 0.35rem 0.5rem;
+    background: var(--mlad-surface-muted);
     border: 1px solid var(--mlad-border-soft);
     border-radius: 0;
     color: var(--md-default-fg-color);
@@ -301,7 +258,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
 }
 
 .md-version__current:hover {
-    background: var(--mlad-surface-strong);
+    background: var(--mlad-surface-solid);
     border-color: var(--mlad-border-strong);
     box-shadow: none;
 }
@@ -328,7 +285,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     background: var(--mlad-surface-solid) !important;
     border: 1px solid var(--mlad-border-soft) !important;
     border-radius: 0;
-    box-shadow: var(--mlad-shadow-soft) !important;
+    box-shadow: none !important;
     list-style: none;
     opacity: 0;
     visibility: hidden;
@@ -425,7 +382,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     }
 
     .md-version__current {
-        padding: 0.35rem;
+        padding: 0.3rem;
     }
 }
 
@@ -435,9 +392,9 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     }
 
     .md-version__current {
-        padding: 0.35rem 0.4rem 0.35rem 0.6rem;
+        padding: 0.3rem 0.35rem 0.3rem 0.5rem;
         font-size: 0.7rem;
-        gap: 0.25rem;
+        gap: 0.2rem;
     }
 
     .md-version__current svg {
@@ -464,7 +421,7 @@ body[data-mlad-scene="none"] .threejs-bg-container,
     }
 }
 
-/* AI chat trigger - sharp, no radius override nuke */
+/* AI chat trigger — sharp, no radius */
 body:not(.canvas-page) .ai-chat-trigger,
 body:not(.canvas-page) .ai-chat-modal * {
     border-radius: 0 !important;

--- a/docs/assets/css/buttons.css
+++ b/docs/assets/css/buttons.css
@@ -1,6 +1,6 @@
 /* ============================================
-   Buttons - Stone Tablets
-   Subtle response, no mechanical snap
+   Buttons — Flat Actions
+   No transforms, no shadows, no radius.
    ============================================ */
 
 .md-button {
@@ -9,9 +9,9 @@
     justify-content: center;
     gap: 0.5rem;
     min-height: 2.75rem;
-    padding: 0.75rem 1.5rem;
+    padding: 0.65rem 1.25rem;
     border: 1px solid transparent;
-    border-radius: var(--mlad-radius-md);
+    border-radius: 0;
     font-size: 0.9rem;
     font-weight: 500;
     line-height: 1.2;
@@ -19,8 +19,7 @@
     transition: background-color var(--mlad-duration-fast) var(--mlad-ease-standard),
         border-color var(--mlad-duration-fast) var(--mlad-ease-standard),
         color var(--mlad-duration-fast) var(--mlad-ease-standard),
-        box-shadow var(--mlad-duration-fast) var(--mlad-ease-standard),
-        transform var(--mlad-duration-fast) var(--mlad-ease-standard);
+        opacity var(--mlad-duration-fast) var(--mlad-ease-standard);
 }
 
 .md-typeset .md-button,
@@ -34,7 +33,7 @@
     margin-right: 0;
 }
 
-/* Primary button - aged bronze / candlelight gold */
+/* Primary button */
 .md-typeset .md-button.md-button--primary,
 .md-content__inner .md-button.md-button--primary,
 .tx-hero__content .md-button.md-button--primary,
@@ -57,16 +56,18 @@
     background: var(--md-accent-fg-color--light) !important;
     background-color: var(--md-accent-fg-color--light) !important;
     border-color: transparent !important;
-    box-shadow: var(--mlad-shadow-button-hover);
-    transform: scale(1.02);
+    box-shadow: none;
+    transform: none;
+    opacity: 0.92;
 }
 
 .md-typeset .md-button.md-button--primary:active,
 .md-button.md-button--primary:active {
-    transform: scale(0.98);
+    opacity: 0.85;
+    transform: none;
 }
 
-/* Secondary button - transparent with hairline */
+/* Secondary button */
 .md-typeset .md-button:not(.md-button--primary),
 .md-button:not(.md-button--primary) {
     background: transparent !important;
@@ -82,21 +83,22 @@
     background: var(--mlad-surface-solid) !important;
     border-color: var(--mlad-border-strong) !important;
     color: var(--md-default-fg-color) !important;
-    box-shadow: var(--mlad-shadow-button-hover);
-    transform: scale(1.02);
+    box-shadow: none;
+    transform: none;
 }
 
 .md-button:not(.md-button--primary):active {
-    transform: scale(0.98);
+    opacity: 0.85;
+    transform: none;
 }
 
-/* Project link - subtle inline action */
+/* Project link */
 .project-link {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.4rem 0.8rem;
-    border-radius: var(--mlad-radius-md);
+    padding: 0.35rem 0.7rem;
+    border-radius: 0;
     font-size: 0.8rem;
     font-weight: 500;
     text-decoration: none;
@@ -126,7 +128,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.45rem 0.8rem;
+    padding: 0.4rem 0.7rem;
     margin: 0.25rem;
     font-size: 0.75rem;
     font-weight: 500;
@@ -134,7 +136,7 @@
     color: var(--md-default-fg-color--light);
     background: transparent;
     border: 1px solid var(--mlad-border-soft);
-    border-radius: var(--mlad-radius-md);
+    border-radius: 0;
     box-shadow: none;
     transition: background-color var(--mlad-duration-fast) var(--mlad-ease-standard),
         border-color var(--mlad-duration-fast) var(--mlad-ease-standard),

--- a/docs/assets/css/cards.css
+++ b/docs/assets/css/cards.css
@@ -1,12 +1,11 @@
 /* ============================================
-   Cards - Tonal Elevation
-   Surfaces shift, not boxes stacked
+   Cards — Whitespace Separation
+   No boxes. Just content and space.
    ============================================ */
 
-/* Grid card layout */
 .grid.cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: var(--mlad-space-lg);
     padding: 0;
     list-style: none;
@@ -16,54 +15,57 @@
 .grid.cards>ul>li {
     display: flex;
     flex-direction: column;
-    padding: var(--mlad-space-lg);
-    background: var(--mlad-surface-solid);
+    padding: var(--mlad-space-md) 0;
+    background: transparent;
     border: none;
-    border-radius: var(--mlad-radius-md);
+    border-top: 1px solid var(--mlad-border-soft);
+    border-radius: 0;
     box-shadow: none;
-    transition: transform var(--mlad-duration-base) var(--mlad-ease-standard),
-        background-color var(--mlad-duration-base) var(--mlad-ease-standard),
-        box-shadow var(--mlad-duration-base) var(--mlad-ease-standard);
+    transition: color var(--mlad-duration-fast) var(--mlad-ease-standard);
 }
 
 .grid.cards>li:hover,
 .grid.cards>ul>li:hover {
-    background: var(--mlad-surface-elevated);
-    box-shadow: var(--mlad-shadow-soft);
-    transform: translateY(-2px);
+    background: transparent;
+    box-shadow: none;
+    transform: none;
 }
 
-[data-md-color-scheme="slate"] .grid.cards>li:hover,
-[data-md-color-scheme="slate"] .grid.cards>ul>li:hover {
-    background: var(--mlad-surface-elevated);
+.grid.cards>li h3,
+.grid.cards>li h4,
+.grid.cards>ul>li h3,
+.grid.cards>ul>li h4 {
+    margin-top: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
 }
 
-/* Blockquote styling - quiet monument */
+/* Blockquote — minimal left rule */
 .md-typeset blockquote {
     position: relative;
     border: none;
-    background: var(--mlad-surface-solid);
+    background: transparent;
     box-shadow: none;
-    padding: var(--mlad-space-md) var(--mlad-space-md) var(--mlad-space-md) var(--mlad-space-lg);
+    padding: var(--mlad-space-sm) var(--mlad-space-sm) var(--mlad-space-sm) var(--mlad-space-md);
     margin: var(--mlad-space-lg) 0;
-    border-radius: var(--mlad-radius-md);
-    color: var(--md-default-fg-color);
+    border-radius: 0;
+    color: var(--md-default-fg-color--light);
 }
 
 .md-typeset blockquote::before {
     content: "";
     position: absolute;
-    top: var(--mlad-space-md);
-    left: var(--mlad-space-sm);
+    top: 0;
+    left: 0;
     width: 2px;
-    height: calc(100% - var(--mlad-space-lg));
+    height: 100%;
     background: var(--md-accent-fg-color);
-    opacity: 0.4;
+    opacity: 0.35;
 }
 
 .md-typeset blockquote p {
     margin: 0;
-    color: var(--md-default-fg-color);
+    color: inherit;
     font-style: italic;
 }
 

--- a/docs/assets/css/chat-widget.css
+++ b/docs/assets/css/chat-widget.css
@@ -14,7 +14,7 @@
     background: var(--mlad-chat-bg);
     color: var(--mlad-chat-fg);
     border: none;
-    box-shadow: var(--mlad-shadow-button);
+    box-shadow: none;
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -31,12 +31,12 @@
 .ai-chat-trigger:hover {
     background: var(--mlad-button-bg-hover);
     color: var(--mlad-chat-fg);
-    box-shadow: var(--mlad-shadow-button-hover);
-    transform: translateX(-50%) scale(1.02);
+    box-shadow: none;
+    transform: translateX(-50%);
 }
 
 .ai-chat-trigger:active {
-    transform: translateX(-50%) scale(0.98);
+    transform: translateX(-50%);
 }
 
 .ai-chat-trigger svg {
@@ -55,8 +55,8 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.35);
-    -webkit-backdrop-filter: blur(8px);
-    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     display: none;
     align-items: flex-start;
     justify-content: center;
@@ -76,7 +76,7 @@
     background: var(--mlad-surface-solid);
     border: 1px solid var(--mlad-border-soft);
     border-radius: 0;
-    box-shadow: var(--mlad-shadow-strong);
+    box-shadow: none;
     width: 100%;
     max-width: 560px;
     max-height: calc(100vh - 96px);
@@ -288,7 +288,7 @@
     background: var(--mlad-surface-elevated);
     border: 1px solid var(--mlad-border-soft);
     border-radius: 0;
-    box-shadow: var(--mlad-shadow-soft);
+    box-shadow: none;
     min-width: 140px;
     padding: 4px;
     opacity: 0;
@@ -675,7 +675,7 @@
 /* Dark mode adjustments */
 @media (prefers-color-scheme: dark) {
     .ai-chat-trigger {
-        box-shadow: var(--mlad-shadow-button);
+        box-shadow: none;
     }
 
     .ai-message-bot .ai-message-content {
@@ -692,7 +692,7 @@
 }
 
 [data-md-color-scheme="slate"] .ai-chat-trigger {
-    box-shadow: var(--mlad-shadow-button);
+    box-shadow: none;
 }
 
 [data-md-color-scheme="slate"] .ai-message-bot .ai-message-content {
@@ -702,7 +702,7 @@
 [data-md-color-scheme="slate"] .ai-chat-menu {
     background: var(--mlad-surface-elevated);
     border-color: var(--mlad-border-soft);
-    box-shadow: var(--mlad-shadow-soft);
+    box-shadow: none;
 }
 
 [data-md-color-scheme="slate"] .ai-chat-menu-btn {
@@ -726,7 +726,7 @@
     border-radius: 0;
     font-size: 0.8rem;
     font-weight: 500;
-    box-shadow: var(--mlad-shadow-button);
+    box-shadow: none;
     opacity: 0;
     transition: opacity var(--mlad-duration-base) var(--mlad-ease-standard),
         transform var(--mlad-duration-base) var(--mlad-ease-standard);

--- a/docs/assets/css/code.css
+++ b/docs/assets/css/code.css
@@ -1,9 +1,8 @@
 /* ============================================
-   Code - Carved Stone Tablets
-   Functional borders justified, everything else quiet
+   Code — Carved Stone
+   Functional borders only. No decoration.
    ============================================ */
 
-/* Code block container */
 .md-typeset pre {
     background: var(--md-code-bg-color);
     border: 1px solid var(--mlad-border-soft);
@@ -13,7 +12,6 @@
     overflow: hidden;
 }
 
-/* Inline code */
 .md-typeset code {
     background: var(--md-code-bg-color);
     border-radius: 0;
@@ -22,7 +20,6 @@
     font-weight: 500;
 }
 
-/* Code block inner content */
 .md-typeset pre > code {
     display: block;
     padding: var(--mlad-space-md);
@@ -37,18 +34,16 @@
     border-radius: 0;
 }
 
-/* Light mode */
 [data-md-color-scheme="default"] .md-typeset pre {
     background: var(--md-code-bg-color);
     border-color: var(--mlad-border-soft);
 }
 
 [data-md-color-scheme="default"] .md-typeset code {
-    background: rgba(26, 24, 20, 0.05);
+    background: rgba(28, 26, 23, 0.06);
     color: var(--md-code-fg-color);
 }
 
-/* Dark mode */
 [data-md-color-scheme="slate"] .md-typeset pre {
     background: var(--md-code-bg-color);
     border-color: var(--mlad-border-soft);
@@ -59,7 +54,6 @@
     color: var(--md-code-fg-color);
 }
 
-/* Inline code in paragraphs, lists, tables */
 .md-typeset p code,
 .md-typeset li code,
 .md-typeset td code {
@@ -67,7 +61,6 @@
     font-weight: 500;
 }
 
-/* Copy Button */
 .md-typeset .md-clipboard {
     position: absolute;
     top: 0.5rem;
@@ -98,7 +91,6 @@
     background: var(--md-default-fg-color--lightest);
 }
 
-/* Filename / Title Header Bar */
 .md-typeset .highlight > .filename,
 .md-typeset .highlighttable > .filename {
     display: flex;
@@ -119,12 +111,10 @@
     border-bottom-color: var(--mlad-border-soft);
 }
 
-/* Code Annotations */
 .md-typeset .md-annotation {
     outline: none;
 }
 
-/* Line Numbers */
 .md-typeset .linenums {
     padding-left: 2.5rem;
     border-right: 1px solid var(--md-default-fg-color--lightest);
@@ -132,7 +122,6 @@
     opacity: 0.4;
 }
 
-/* Highlighted Lines */
 .md-typeset .highlight .hll {
     display: block;
     margin: 0 calc(-1 * var(--mlad-space-md));
@@ -141,14 +130,13 @@
 }
 
 [data-md-color-scheme="default"] .md-typeset .highlight .hll {
-    background: rgba(26, 24, 20, 0.05);
+    background: rgba(28, 26, 23, 0.05);
 }
 
 [data-md-color-scheme="slate"] .md-typeset .highlight .hll {
     background: rgba(232, 228, 220, 0.06);
 }
 
-/* Tabbed Code Blocks */
 .md-typeset .tabbed-set {
     border: 1px solid var(--mlad-border-soft);
     border-radius: 0;
@@ -199,7 +187,6 @@
     border-color: var(--mlad-border-soft);
 }
 
-/* Remove inner code block styling when inside tabbed sets */
 .md-typeset .tabbed-content pre {
     border: none;
     border-radius: 0;
@@ -211,7 +198,6 @@
     background: var(--md-code-bg-color);
 }
 
-/* Responsive code block sizing */
 @media (max-width: 1024px) {
     .md-typeset pre > code {
         font-size: 0.8rem;

--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -1,6 +1,6 @@
 /* ============================================
-   Landing - Monumental Scale
-   Content breathes over the animated background
+   Landing — Content Floats
+   No glass boxes. Sections breathe through whitespace.
    ============================================ */
 
 .landing-page .md-content__button {
@@ -26,20 +26,20 @@
 .landing-page .tx-hero,
 .landing-page .tx-container,
 .landing-page section.md-typeset {
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto var(--mlad-space-lg);
-    padding: clamp(3rem, 6vw, 5rem);
-    background: var(--mlad-surface-overlay);
-    -webkit-backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
-    backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
+    padding: var(--mlad-space-xl) var(--mlad-space-md);
+    background: transparent;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     border: none;
-    border-radius: var(--mlad-radius-lg);
+    border-radius: 0;
     box-shadow: none;
 }
 
 .landing-page .tx-hero {
-    margin-top: var(--mlad-space-sm);
-    gap: clamp(2rem, 4vw, 4rem);
+    margin-top: 0;
+    gap: var(--mlad-space-lg);
 }
 
 .landing-page .tx-hero__content {
@@ -63,17 +63,18 @@
 .landing-page .grid.cards > li,
 .landing-page .grid.cards > ul > li,
 .landing-page .grid > blockquote {
-    background: var(--mlad-surface-overlay);
-    -webkit-backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
-    backdrop-filter: blur(var(--mlad-backdrop-blur)) saturate(1.1);
+    background: transparent;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
     border: none;
-    border-radius: var(--mlad-radius-md);
+    border-top: 1px solid var(--mlad-border-soft);
+    border-radius: 0;
 }
 
 .landing-page .grid.cards > li:hover,
 .landing-page .grid.cards > ul > li:hover {
-    background: var(--mlad-surface-elevated);
-    border-color: transparent;
+    background: transparent;
+    border-color: var(--mlad-border-soft);
 }
 
 .landing-page .grid > blockquote {
@@ -114,9 +115,9 @@
     .landing-page .tx-hero,
     .landing-page .tx-container,
     .landing-page section.md-typeset {
-        padding: var(--mlad-space-lg);
-        margin-left: var(--mlad-space-xs);
-        margin-right: var(--mlad-space-xs);
+        padding: var(--mlad-space-lg) var(--mlad-space-md);
+        margin-left: 0;
+        margin-right: 0;
     }
 
     .landing-page .tx-hero {

--- a/docs/assets/css/layout.css
+++ b/docs/assets/css/layout.css
@@ -1,15 +1,14 @@
 /* ============================================
-   Layout - Classical Proportion
-   Space as structure, not decoration
+   Layout — Quiet Structure
+   Space as structure. No decoration.
    ============================================ */
 
-/* Hero section - generous, monumental */
 .tx-hero {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    padding: clamp(5rem, 10vw, 10rem) 0;
-    gap: clamp(2rem, 4vw, 4rem);
+    padding: var(--mlad-space-xl) 0;
+    gap: var(--mlad-space-lg);
 }
 
 .tx-hero__intro {
@@ -30,46 +29,43 @@
 }
 
 .tx-hero__content {
-    flex: 1 1 500px;
+    flex: 1 1 400px;
     max-width: 600px;
-    padding: 0 2rem;
+    padding: 0 1rem;
     display: flex;
     flex-direction: column;
-    gap: var(--mlad-space-lg);
+    gap: var(--mlad-space-md);
 }
 
 .tx-hero__image {
-    flex: 1 1 350px;
+    flex: 1 1 300px;
     display: flex;
     justify-content: center;
-    padding: 2rem;
+    padding: 1rem;
 }
 
 .tx-hero__image img {
-    width: min(420px, 100%);
+    width: min(360px, 100%);
     height: auto;
     border: none;
-    border-radius: var(--mlad-radius-lg);
+    border-radius: 0;
     box-shadow: none;
     object-fit: cover;
 }
 
-/* Main content container */
 .tx-container {
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto;
     padding: var(--mlad-space-xl) var(--mlad-space-md);
 }
 
-/* Two column layout */
 .tx-columns {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: var(--mlad-space-xl);
-    margin: var(--mlad-space-xl) 0;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--mlad-space-lg);
+    margin: var(--mlad-space-lg) 0;
 }
 
-/* Responsive adjustments */
 @media screen and (max-width: 76.25rem) {
     .tx-hero__content {
         padding: 0 var(--mlad-space-md);
@@ -80,8 +76,8 @@
     .tx-hero {
         flex-direction: column;
         text-align: center;
-        padding: clamp(3rem, 8vw, 5rem) 0;
-        gap: var(--mlad-space-lg);
+        padding: var(--mlad-space-lg) 0;
+        gap: var(--mlad-space-md);
     }
 
     .tx-hero__content {
@@ -89,7 +85,7 @@
         order: 1;
         display: flex;
         flex-direction: column;
-        gap: var(--mlad-space-md);
+        gap: var(--mlad-space-sm);
         align-items: center;
     }
 
@@ -114,7 +110,7 @@
     }
 
     .tx-hero__image img {
-        width: min(340px, 90vw);
+        width: min(300px, 80vw);
         margin-inline: auto;
     }
 }
@@ -134,14 +130,12 @@
 }
 
 /* ============================================
-   Navigation Sidebar - Quiet Hierarchy
-   Whitespace and weight, not borders
+   Navigation Sidebar — Flat Hierarchy
    ============================================ */
 
-/* Top-level sections */
 .md-nav[data-md-level="0"]>.md-nav__list>.md-nav__item {
-    padding-top: var(--mlad-space-sm);
-    padding-bottom: var(--mlad-space-sm);
+    padding-top: var(--mlad-space-xs);
+    padding-bottom: var(--mlad-space-xs);
     border-bottom: none;
     margin-bottom: 0;
 }
@@ -150,28 +144,26 @@
     border-bottom: none;
 }
 
-/* Top-level section titles - quiet authority */
 .md-nav[data-md-level="0"]>.md-nav__list>.md-nav__item>.md-nav__link,
 .md-nav[data-md-level="0"]>.md-nav__list>.md-nav__item>.md-nav__container>.md-nav__link {
     font-weight: 500;
     font-size: 0.8rem;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
     color: var(--md-default-fg-color--light);
 }
 
-/* Level 1 - major subsections */
 .md-nav[data-md-level="1"]>.md-nav__list>.md-nav__item {
     padding-left: 0;
     border-left: none;
     margin-bottom: 0;
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
 }
 
 .md-nav[data-md-level="1"]>.md-nav__list>.md-nav__item:last-child {
     margin-bottom: 0;
-    padding-bottom: 0.25rem;
+    padding-bottom: 0.2rem;
 }
 
 .md-nav[data-md-level="1"]>.md-nav__list>.md-nav__item:hover {
@@ -185,21 +177,20 @@
     color: var(--md-default-fg-color);
 }
 
-/* Level 2+ - deeper nesting, quieter */
 .md-nav[data-md-level="2"]>.md-nav__list,
 .md-nav[data-md-level="3"]>.md-nav__list,
 .md-nav[data-md-level="4"]>.md-nav__list {
     border-left: none;
-    margin-left: 0.75rem;
-    padding-left: 0.75rem;
+    margin-left: 0.5rem;
+    padding-left: 0.5rem;
 }
 
 .md-nav[data-md-level="2"]>.md-nav__list>.md-nav__item,
 .md-nav[data-md-level="3"]>.md-nav__list>.md-nav__item,
 .md-nav[data-md-level="4"]>.md-nav__list>.md-nav__item {
     margin-bottom: 0;
-    padding-top: 0.2rem;
-    padding-bottom: 0.2rem;
+    padding-top: 0.15rem;
+    padding-bottom: 0.15rem;
 }
 
 .md-nav[data-md-level="2"]>.md-nav__list>.md-nav__item>.md-nav__link,
@@ -216,14 +207,12 @@
     color: var(--md-default-fg-color--lighter);
 }
 
-/* Nav link text */
 .md-nav__link {
     white-space: normal;
     max-width: 100%;
     transition: color var(--mlad-duration-fast) var(--mlad-ease-standard);
 }
 
-/* Active and hover states - color only, no background */
 .md-nav__link:hover {
     color: var(--md-accent-fg-color) !important;
     background: transparent !important;
@@ -275,7 +264,10 @@ label.md-nav__link[for]:active {
     background-color: transparent !important;
 }
 
-/* Mobile nav drawer */
+/* ============================================
+   Mobile Nav Drawer — Solid & Clean
+   ============================================ */
+
 .md-nav--primary .md-nav__title,
 .md-nav--primary .md-nav__item,
 .md-nav--primary .md-nav__item--active,
@@ -300,6 +292,7 @@ label.md-nav__link[for]:active {
     margin: 0;
 }
 
+/* Mobile drawer: solid surface, generous spacing, clean typography */
 @media screen and (max-width: 76.1875em) {
     .md-nav--primary,
     .md-nav--primary .md-nav,
@@ -328,7 +321,39 @@ label.md-nav__link[for]:active {
     }
 
     .md-nav--primary .md-nav__link {
-        font-size: 0.9rem !important;
+        font-size: 0.95rem !important;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+
+    /* Drawer container */
+    .md-drawer {
+        background: var(--mlad-surface-solid) !important;
+        border-right: 1px solid var(--mlad-border-soft) !important;
+    }
+
+    .md-drawer__content,
+    .md-nav--primary,
+    .md-sidebar--primary .md-sidebar__scrollwrap {
+        background: transparent !important;
+    }
+
+    .md-nav--primary .md-nav__title {
+        font-size: 0.85rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--md-default-fg-color--light);
+        padding: var(--mlad-space-md) var(--mlad-space-md) var(--mlad-space-sm);
+    }
+
+    .md-nav--primary .md-nav__list {
+        padding: 0 var(--mlad-space-md);
+    }
+
+    /* Overlay */
+    [data-md-toggle="drawer"]:checked ~ .md-overlay {
+        background-color: rgba(0, 0, 0, 0.35) !important;
     }
 }
 

--- a/docs/assets/css/pull-to-refresh.css
+++ b/docs/assets/css/pull-to-refresh.css
@@ -34,7 +34,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: var(--mlad-shadow-button, 3px 3px 0 rgba(0, 0, 0, 0.12));
+    box-shadow: none;
     opacity: 0;
     transform: scale(0.5);
     transition: opacity 0.2s ease, transform 0.2s ease;

--- a/docs/assets/css/theme.css
+++ b/docs/assets/css/theme.css
@@ -1,15 +1,16 @@
 /* ============================================
-   Theme - Monumental Minimalism Design Tokens
-   Classical proportion, material warmth, quiet grandeur
+   Theme — Elemental Ink
+   Ink on paper. No glass, no blur, no shadows.
+   Water, Earth, Fire, Air — balanced through restraint.
    ============================================ */
 
 :root {
-    --md-primary-fg-color: #1a1814;
+    --md-primary-fg-color: #1c1a17;
     --md-primary-fg-color--light: #3d3a34;
-    --md-primary-fg-color--dark: #0d0c0a;
-    --md-accent-fg-color: #a67c52;
-    --md-accent-fg-color--light: #8a6542;
-    --md-accent-fg-color--transparent: rgba(166, 124, 82, 0.12);
+    --md-primary-fg-color--dark: #12110f;
+    --md-accent-fg-color: #2d6a5e;
+    --md-accent-fg-color--light: #3d8a7a;
+    --md-accent-fg-color--transparent: rgba(45, 106, 94, 0.12);
 
     --md-link-color: var(--md-primary-fg-color);
     --md-link-color-hover: var(--md-accent-fg-color);
@@ -20,126 +21,90 @@
     --mlad-radius-pill: 0;
 
     --mlad-space-xs: 0.5rem;
-    --mlad-space-sm: 1rem;
-    --mlad-space-md: 1.75rem;
-    --mlad-space-lg: 3rem;
-    --mlad-space-xl: 5rem;
-    --mlad-space-2xl: 8rem;
-    --mlad-space-3xl: 12rem;
+    --mlad-space-sm: 0.75rem;
+    --mlad-space-md: 1.25rem;
+    --mlad-space-lg: 2rem;
+    --mlad-space-xl: 3rem;
 
-    --mlad-duration-fast: 200ms;
-    --mlad-duration-base: 300ms;
-    --mlad-duration-slow: 500ms;
-    --mlad-ease-standard: cubic-bezier(0.25, 0.1, 0.25, 1);
+    --mlad-duration-fast: 150ms;
+    --mlad-duration-base: 200ms;
+    --mlad-duration-slow: 300ms;
+    --mlad-ease-standard: ease-out;
 
-    --mlad-backdrop-blur: 16px;
-    --mlad-reading-width: 72ch;
+    --mlad-reading-width: 68ch;
 }
 
 [data-md-color-scheme="default"] {
-    --md-default-bg-color: #f7f5f0;
-    --md-default-fg-color: #1a1814;
-    --md-default-fg-color--light: #5c5850;
-    --md-default-fg-color--lighter: #8a857a;
-    --md-default-fg-color--lightest: rgba(26, 24, 20, 0.08);
+    --md-default-bg-color: #f7f5f2;
+    --md-default-fg-color: #1c1a17;
+    --md-default-fg-color--light: #5c5954;
+    --md-default-fg-color--lighter: #8a8680;
+    --md-default-fg-color--lightest: rgba(28, 26, 23, 0.06);
 
-    --md-code-bg-color: #ebe7de;
-    --md-code-fg-color: #1a1814;
-    --md-primary-bg-color: #f7f5f0;
+    --md-code-bg-color: #e6e2dc;
+    --md-code-fg-color: #1c1a17;
+    --md-primary-bg-color: #f7f5f2;
 
-    --mlad-surface-solid: #f0ece4;
-    --mlad-surface-muted: #ebe7de;
-    --mlad-surface-strong: #f7f5f0;
-    --mlad-surface-elevated: #ffffff;
-    --mlad-surface-overlay: rgba(247, 245, 240, 0.85);
+    --mlad-surface-solid: #eeece8;
+    --mlad-surface-muted: #e6e2dc;
 
-    --mlad-border-soft: rgba(26, 24, 20, 0.06);
-    --mlad-border-strong: rgba(26, 24, 20, 0.10);
-    --mlad-shadow-soft: 0 4px 24px rgba(26, 24, 20, 0.04);
-    --mlad-shadow-strong: 0 8px 32px rgba(26, 24, 20, 0.06);
-    --mlad-shadow-button: 0 2px 8px rgba(26, 24, 20, 0.06);
-    --mlad-shadow-button-hover: 0 4px 16px rgba(26, 24, 20, 0.08);
-    --mlad-muted-fg: #8a857a;
-    --mlad-body-wash: rgba(26, 24, 20, 0.02);
+    --mlad-border-soft: rgba(28, 26, 23, 0.08);
+    --mlad-border-strong: rgba(28, 26, 23, 0.14);
 
-    --mlad-button-bg: #1a1814;
-    --mlad-button-fg: #f7f5f0;
-    --mlad-button-border: rgba(26, 24, 20, 0.10);
+    --mlad-button-bg: #1c1a17;
+    --mlad-button-fg: #f7f5f2;
     --mlad-button-bg-hover: #2d2a24;
-    --mlad-button-secondary-bg: #f0ece4;
+    --mlad-button-secondary-bg: transparent;
 
-    --mlad-header-bg: rgba(247, 245, 240, 0.90);
-    --mlad-header-fg: #1a1814;
-    --mlad-menu-btn-bg-hover: rgba(26, 24, 20, 0.04);
+    --mlad-header-bg: #f7f5f2;
+    --mlad-header-fg: #1c1a17;
 
-    --mlad-chat-bg: #1a1814;
-    --mlad-chat-fg: #f7f5f0;
-
-    --mlad-scene-opacity-home: 0.55;
-    --mlad-scene-opacity-page: 0.28;
-    --mlad-scene-opacity-mobile: 0.18;
-    --mlad-scene-opacity-home-mobile: 0.35;
+    --mlad-chat-bg: #1c1a17;
+    --mlad-chat-fg: #f7f5f2;
 }
 
 [data-md-color-scheme="slate"] {
-    --md-default-bg-color: #0d0c0a;
+    --md-default-bg-color: #12110f;
     --md-default-fg-color: #e8e4dc;
     --md-default-fg-color--light: #a39e94;
     --md-default-fg-color--lighter: #6b665e;
-    --md-default-fg-color--lightest: rgba(232, 228, 220, 0.10);
+    --md-default-fg-color--lightest: rgba(232, 228, 220, 0.08);
 
-    --md-code-bg-color: #161513;
+    --md-code-bg-color: #1a1916;
     --md-code-fg-color: #e8e4dc;
 
     --md-primary-fg-color: #e8e4dc;
     --md-primary-fg-color--light: #f5f1e9;
     --md-primary-fg-color--dark: #c4c0b8;
-    --md-primary-bg-color: #0d0c0a;
-    --md-accent-fg-color: #c9a96e;
-    --md-accent-fg-color--light: #d4b87d;
-    --md-accent-fg-color--transparent: rgba(201, 169, 110, 0.15);
+    --md-primary-bg-color: #12110f;
+    --md-accent-fg-color: #c49a5a;
+    --md-accent-fg-color--light: #d4aa6a;
+    --md-accent-fg-color--transparent: rgba(196, 154, 90, 0.15);
     --md-link-color: #e8e4dc;
-    --md-link-color-hover: #c9a96e;
+    --md-link-color-hover: #c49a5a;
 
-    --mlad-surface-solid: #141312;
-    --mlad-surface-muted: #161513;
-    --mlad-surface-strong: #1c1b19;
-    --mlad-surface-elevated: #242320;
-    --mlad-surface-overlay: rgba(13, 12, 10, 0.82);
+    --mlad-surface-solid: #1c1b18;
+    --mlad-surface-muted: #1a1916;
 
-    --mlad-border-soft: rgba(232, 228, 220, 0.06);
-    --mlad-border-strong: rgba(232, 228, 220, 0.10);
-    --mlad-shadow-soft: 0 4px 24px rgba(0, 0, 0, 0.18);
-    --mlad-shadow-strong: 0 8px 32px rgba(0, 0, 0, 0.24);
-    --mlad-shadow-button: 0 2px 8px rgba(0, 0, 0, 0.20);
-    --mlad-shadow-button-hover: 0 4px 16px rgba(0, 0, 0, 0.28);
-    --mlad-muted-fg: #a39e94;
-    --mlad-body-wash: rgba(232, 228, 220, 0.015);
+    --mlad-border-soft: rgba(232, 228, 220, 0.08);
+    --mlad-border-strong: rgba(232, 228, 220, 0.14);
 
     --mlad-button-bg: #e8e4dc;
-    --mlad-button-fg: #0d0c0a;
-    --mlad-button-border: rgba(232, 228, 220, 0.12);
+    --mlad-button-fg: #12110f;
     --mlad-button-bg-hover: #d4cfc6;
-    --mlad-button-secondary-bg: #1c1b19;
+    --mlad-button-secondary-bg: transparent;
 
-    --mlad-header-bg: rgba(13, 12, 10, 0.90);
+    --mlad-header-bg: #12110f;
     --mlad-header-fg: #e8e4dc;
-    --mlad-menu-btn-bg-hover: rgba(232, 228, 220, 0.05);
 
     --mlad-chat-bg: #e8e4dc;
-    --mlad-chat-fg: #0d0c0a;
-
-    --mlad-scene-opacity-home: 0.55;
-    --mlad-scene-opacity-page: 0.28;
-    --mlad-scene-opacity-mobile: 0.18;
-    --mlad-scene-opacity-home-mobile: 0.35;
+    --mlad-chat-fg: #12110f;
 }
 
 body {
     position: relative;
     isolation: isolate;
     background: var(--md-default-bg-color);
-    background-image: linear-gradient(180deg, var(--mlad-body-wash), transparent 30%);
     color: var(--md-default-fg-color);
 }
 
@@ -160,15 +125,13 @@ body {
     text-underline-offset: 0.2em;
     text-decoration-color: var(--mlad-border-strong);
     transition: color var(--mlad-duration-fast) var(--mlad-ease-standard),
-        text-decoration-color var(--mlad-duration-fast) var(--mlad-ease-standard),
-        opacity var(--mlad-duration-fast) var(--mlad-ease-standard);
+        text-decoration-color var(--mlad-duration-fast) var(--mlad-ease-standard);
 }
 
 .md-typeset a:not(.md-button):hover,
 .md-typeset a:not(.md-button):focus-visible {
     color: var(--md-link-color-hover);
     text-decoration-color: var(--md-accent-fg-color);
-    opacity: 1;
 }
 
 .md-typeset strong,
@@ -180,7 +143,7 @@ body {
 .surface-card {
     background: var(--mlad-surface-solid);
     border: none;
-    border-radius: var(--mlad-radius-lg);
+    border-radius: 0;
     box-shadow: none;
 }
 

--- a/docs/assets/css/typography.css
+++ b/docs/assets/css/typography.css
@@ -1,6 +1,6 @@
 /* ============================================
-   Typography - Monumental Scale
-   Cathedral hierarchy through size and weight
+   Typography — Human Scale
+   Readable, balanced, quiet hierarchy.
    ============================================ */
 
 :root {
@@ -12,41 +12,38 @@ body {
     font-feature-settings: "liga" 1, "ss01" 1;
 }
 
-/* Body text - generous and open */
 .md-typeset {
     font-family: var(--mlad-text-font);
     font-size: 1rem;
-    line-height: 1.75;
-    letter-spacing: -0.01em;
+    line-height: 1.7;
+    letter-spacing: 0;
 }
 
-/* Headings - monumental scale, airy weight */
 .md-typeset h1 {
-    font-size: clamp(2rem, 4vw, 3rem);
-    font-weight: 400;
-    line-height: 1.15;
-    letter-spacing: -0.02em;
+    font-size: 1.75rem;
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: 0;
     margin-top: 0;
 }
 
 .md-typeset h2 {
-    font-size: clamp(1.5rem, 3vw, 2.25rem);
-    font-weight: 400;
-    line-height: 1.25;
-    letter-spacing: -0.01em;
+    font-size: 1.4rem;
+    font-weight: 600;
+    line-height: 1.3;
     margin-top: var(--mlad-space-xl);
 }
 
 .md-typeset h3 {
-    font-size: 1.25rem;
-    font-weight: 500;
+    font-size: 1.15rem;
+    font-weight: 600;
     line-height: 1.35;
     margin-top: var(--mlad-space-lg);
 }
 
 .md-typeset h4 {
-    font-size: 1.1rem;
-    font-weight: 500;
+    font-size: 1rem;
+    font-weight: 600;
     line-height: 1.4;
 }
 
@@ -59,22 +56,20 @@ body {
     text-transform: uppercase;
 }
 
-/* Hero-specific H1 - even more monumental */
 .tx-hero__content h1 {
-    font-size: clamp(2.5rem, 5vw, 4rem);
-    font-weight: 300;
-    line-height: 1.1;
-    letter-spacing: -0.03em;
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: 0;
 }
 
 .tx-hero__content p {
     text-shadow: none;
-    font-size: 1.1rem;
-    line-height: 1.7;
+    font-size: 1.05rem;
+    line-height: 1.65;
     color: var(--md-default-fg-color--light);
 }
 
-/* Paragraph spacing */
 .md-typeset p {
     margin-bottom: var(--mlad-space-md);
 }
@@ -83,7 +78,6 @@ body {
     margin-bottom: 0;
 }
 
-/* Lists - generous spacing */
 .md-typeset ul,
 .md-typeset ol {
     margin: var(--mlad-space-md) 0;
@@ -91,37 +85,25 @@ body {
 }
 
 .md-typeset li {
-    margin-bottom: 0.5rem;
-}
-
-/* Responsive adjustments */
-@media screen and (max-width: 76.25rem) {
-    .md-typeset {
-        font-size: 0.95rem;
-        line-height: 1.7;
-    }
-
-    .tx-hero__content h1 {
-        font-size: clamp(2rem, 6vw, 3rem);
-    }
+    margin-bottom: 0.4rem;
 }
 
 @media screen and (max-width: 48rem) {
     .md-typeset {
         font-size: 0.95rem;
-        line-height: 1.7;
+        line-height: 1.65;
     }
 
     .md-typeset h1 {
-        font-size: 1.75rem;
+        font-size: 1.5rem;
     }
 
     .md-typeset h2 {
-        font-size: 1.4rem;
+        font-size: 1.25rem;
     }
 
     .tx-hero__content h1 {
-        font-size: 2rem;
+        font-size: 1.75rem;
     }
 
     .tx-hero__content p {

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -110,8 +110,8 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="SimplifiedLife">
 <link rel="apple-touch-icon" href="{{ 'assets/images/favicon/icon-192.png' | url }}">
-<meta name="theme-color" content="#0d0c0a">
-<meta name="msapplication-TileColor" content="#0d0c0a">
+<meta name="theme-color" content="#12110f">
+<meta name="msapplication-TileColor" content="#12110f">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5, viewport-fit=cover">
 <script src="{{ 'assets/js/console-patch.js' | url }}"></script>
@@ -182,7 +182,8 @@
   })();
 </script>
 
-<script type="module" src="{{ 'assets/js/threejs-background/main.js' | url }}"></script>
+<!-- Three.js background disabled for minimal design -->
+<!-- <script type="module" src="{{ 'assets/js/threejs-background/main.js' | url }}"></script> -->
 <script type="module" src="{{ 'assets/js/canvas/scene/main.js' | url }}"></script>
 
 <script src="{{ 'assets/js/chat-widget/lib/config.js' | url }}"></script>


### PR DESCRIPTION
## Summary

Complete pivot from monumental minimalism to an Avatar: The Last Airbender inspired absolutely minimalistic design.

## Changes

- **Remove all backdrop-filter blur** — performance killer on mobile/tablet
- **Remove all box-shadow** — flat surfaces only
- **Disable Three.js background scene** —  + script commented out
- **Flat solid surfaces** — only 2 tiers (background + surface), no overlay/elevated/muted
- **Human-scale typography** — H1 1.75rem, body 1rem, no negative letter-spacing
- **Mobile drawer fix** — solid bg, clean border, generous spacing, no blur
- **Cards** — whitespace-separated, no backgrounds or borders
- **Buttons** — flat, no scale transforms on hover/active
- **Color palette** — water-teal  (light) / fire-ember  (dark)
- **Insights docs** —  and  updated to reflect new direction

## Motivation

The monumental minimalism redesign had serious issues on mobile and tablet: backdrop-filter blur caused repaint jank, the Three.js scene added overhead, and the typography was too large for small screens. This strips everything to ink-on-paper simplicity.

## Checklist

- [x] Desktop light/dark tested visually
- [x] Mobile drawer styling corrected
- [x] No new shadows or blur introduced
- [x] Insights docs updated