### PR TITLE
docs: add GitNexus integration and branch strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,18 @@
 # AGENTS.md - My Life as a Dev
 
-## Quick Reference
+## Current Shape
 
 - **Generator**: Zensical (MkDocs Material-based)
-- **Serve**: `make serve`
-- **Build**: `make build`
-- **CLI**: `doc-cli`
+- **Content**: Developer journey, learning notes, platform experiments, docs-as-code workflows
+- **Structure**: `docs/` contains published content, `config/zensical/` has modular config, `scripts/` has Rust CLI and Python helpers
+- **Deploy**: GitHub Pages via `make build` → `gh-pages` branch
 
-## Critical Rules
+## Branch Strategy
 
-- **ALWAYS use `uv`** for Python - never `pip` directly
-- **ALWAYS use `agent-browser`** for browser automation - never Playwright MCP
-- **No emojis** in commits, docs, or comments
+- **`develop`**: default base for PRs. Experimentation and quick iteration.
+- **`main`**: tagged releases only. PRs merge into `develop` first, then
+  `develop` fast-forwards into `main` at release time.
+- **Feature branches**: branch from `develop`, PR against `develop`.
 
 ## Quick Commands
 
@@ -22,16 +23,11 @@ make build    # Build site with Zensical
 doc-cli       # Interactive CLI (uses .venv automatically)
 ```
 
-## Agent Browser
+## Critical Rules
 
-```bash
-cd /tmp/agent-browser
-./bin/agent-browser open "http://localhost:8001/my-life-as-a-dev/"
-./bin/agent-browser snapshot
-./bin/agent-browser eval "..."
-./bin/agent-browser console
-./bin/agent-browser close
-```
+- **ALWAYS use `uv`** for Python - never `pip` directly
+- **ALWAYS use `agent-browser`** for browser automation - never Playwright MCP
+- **No emojis** in commits, docs, or comments
 
 ## Core Rules
 
@@ -59,3 +55,55 @@ See `.github/skills/` for detailed procedures:
 - Stop and explain before major architectural changes
 - One change per commit, commit before starting next
 - Do not bundle unrelated work into the same commit
+
+## GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **my-life-as-a-dev** (4151 symbols, 6382 relationships, 159 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+
+### Quick Commands
+
+```bash
+make gn-analyze    # Re-index the codebase
+make gn-status     # Check index freshness
+make gn-clean      # Delete the index
+```
+
+### Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+
+### Never Do
+
+- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
+
+### Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/my-life-as-a-dev/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/my-life-as-a-dev/clusters` | All functional areas |
+| `gitnexus://repo/my-life-as-a-dev/processes` | All execution flows |
+| `gitnexus://repo/my-life-as-a-dev/process/{name}` | Step-by-step execution trace |
+
+### Skill References
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) — all agent instructions live there.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup serve build cli config check-config optimize-images test
+.PHONY: help setup serve build cli config check-config optimize-images test gn-analyze gn-status gn-clean
 
 DEV_ADDR ?= 0.0.0.0:8001
 
@@ -11,6 +11,11 @@ help:
 	@echo "  make cli             - Run documentation CLI tools"
 	@echo "  make optimize-images - Optimize images (WebP, responsive sizes, LQIP)"
 	@echo "  make test            - Run tests"
+	@echo ""
+	@echo "GitNexus (Code Intelligence):"
+	@echo "  make gn-analyze        - Re-index the codebase"
+	@echo "  make gn-status         - Check index freshness"
+	@echo "  make gn-clean          - Delete the index"
 
 setup:
 	uv pip install --upgrade pip
@@ -60,4 +65,14 @@ test:
 # Run image optimizer tests only
 test-optimizer:
 	uv run python -m pytest tests/test_image_optimizer.py -v
+
+# GitNexus — Code Intelligence
+gn-analyze:
+	node .gitnexus/run.cjs analyze
+
+gn-status:
+	node .gitnexus/run.cjs status
+
+gn-clean:
+	node .gitnexus/run.cjs clean
 


### PR DESCRIPTION
This PR adds GitNexus code intelligence integration and establishes the branch strategy for the repository.

## Changes
- Add GitNexus code intelligence section to AGENTS.md
- Add branch strategy documentation (develop -> main for tagged releases)
- Add GitNexus Makefile targets (gn-analyze, gn-status, gn-clean)
- Simplify CLAUDE.md to reference AGENTS.md

## GitNexus Index
- 4151 symbols, 6382 relationships, 159 execution flows
- Index is up-to-date on develop branch