### PR TITLE
chore: ignore graphify-out output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tmp/
 
 # Local scratch pad - never commit
 scratch/
+
+# Graphify knowledge graph output - never commit
+graphify-out/


### PR DESCRIPTION
Adds /graphify-out/ to .gitignore matching the terminal-jarvis precedent, so generated knowledge graph output can never be pushed.