### PR TITLE
Merge develop into main (ignore graphify-out)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tmp/
 
 # Local scratch pad - never commit
 scratch/
+
+# Graphify knowledge graph output - never commit
+graphify-out/


### PR DESCRIPTION
Rolls the gitignore guard for generated graph output (PR #159) onto main so  is excluded everywhere, including deploys.